### PR TITLE
Docs-first cleanup: align specyrd role help with installed stubs

### DIFF
--- a/specy_road/specyrd_cli.py
+++ b/specy_road/specyrd_cli.py
@@ -120,7 +120,7 @@ def _build_parser() -> argparse.ArgumentParser:
             "Install only the stubs relevant to a role: "
             "pm (validate, export, author, sync, list-nodes, show-node, "
             "add-node, review-node), dev (validate, brief, claim, finish, "
-            "do-next-task), or both (same as omitting --role: all 13 stubs). "
+            "do-next-task), or both (same as omitting --role: all 14 stubs). "
             "With --no-prompt this flag is required."
         ),
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- ran the docs-first cleanup workflow from `prompts/cleanup_prompts.md`
- audited size limits, documentation hygiene, and dead-code signals against repository docs
- applied one high-confidence cleanup fix in CLI help text

## Cleanup findings and action
### File/function size enforcement
- Ran `validate_file_limits.py` using documented limits in `constraints/file-limits.yaml`
- Result: no file/function limit violations

### Documentation hygiene
- Found stale/mismatched help text in `specy_road/specyrd_cli.py`
- `--role both` help text said `all 13 stubs`, but current `COMMAND_FILES` defines 14 stubs
- Updated help text to `all 14 stubs`

### Dead-code cleanup scan
- Searched for common scaffolding/dead-code signals (`TODO`, `FIXME`, `NotImplementedError`, placeholder returns)
- No safe, high-confidence dead-code removals identified in this pass

## Verification gates run
- `PYTHONPATH=/workspace python3 specy_road/bundled_scripts/validate_roadmap.py --repo-root tests/fixtures/specy_road_dogfood`
- `PYTHONPATH=/workspace python3 specy_road/bundled_scripts/export_roadmap_md.py --check --repo-root tests/fixtures/specy_road_dogfood`
- `PYTHONPATH=/workspace python3 specy_road/bundled_scripts/validate_file_limits.py`
- `PYTHONPATH=/workspace python3 -m pytest`

All gates passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cf17d1e-8761-4f85-be66-4967caafd8c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cf17d1e-8761-4f85-be66-4967caafd8c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Documentation:
- Update specyrd CLI --role help text to reference 14 stubs instead of 13 to match the current stub set.