### PR TITLE
chore(ci): batch GitHub Actions version updates

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,10 +10,10 @@ jobs:
   roadmap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Assert packaged Gantt UI static assets exist
         run: test -f specy_road/pm_gantt_static/index.html
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install Python dependencies (frozen lock)
@@ -32,14 +32,14 @@ jobs:
           set -e
       - name: Upload pip-audit JSON
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pip-audit-results
           path: pip-audit-results.json
           if-no-files-found: ignore
       - name: Enforce pip-audit exit code
         run: test "$(cat pip-audit.exitcode)" -eq 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -60,7 +60,7 @@ jobs:
           set -e
       - name: Upload npm audit JSON
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: npm-audit-results
           path: npm-audit-results.json
@@ -110,7 +110,7 @@ jobs:
             --output-file osv-scanner-results.json
       - name: Upload OSV-Scanner JSON
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: osv-scanner-results
           path: osv-scanner-results.json


### PR DESCRIPTION
## Summary
- Batch the open Dependabot GitHub Actions bumps (#5-#8) into one maintainer PR.
- Update `.github/workflows/validate.yml` to use `actions/checkout@v6`, `actions/setup-python@v6`, `actions/setup-node@v6`, and `actions/upload-artifact@v7`.
- Reduce PR churn by landing CI action updates together and superseding individual bot PRs.

## Test plan
- [ ] Let GitHub `Validate roadmap` workflow run for this PR.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Build:
- Bump versions of actions/checkout, actions/setup-python, actions/setup-node, and actions/upload-artifact in the validate workflow.