### PR TITLE
feat(ci): automated tag-driven release publish (PyPI + TestPyPI via OIDC)

### DIFF
--- a/.github/workflows/main-release-tag-gate.yml
+++ b/.github/workflows/main-release-tag-gate.yml
@@ -1,5 +1,16 @@
 name: Main Release Tag Gate
 
+# Enforces release-marker discipline for PRs to main, and creates the
+# corresponding v-prefixed tag on merge. The release-publish workflow
+# (.github/workflows/release-publish.yml) listens for those tags and
+# routes finals to PyPI, prereleases to TestPyPI.
+#
+# Accepted release-marker syntaxes:
+#   PR title:  "release: v0.1.0" or "release: v0.1.0-rc1"
+#   PR label:  "release:v0.1.0"   or "release:v0.1.0-rc1"
+#
+# Created tag (always v-prefixed):  v0.1.0  /  v0.1.0-rc1
+
 on:
   pull_request:
     branches: [main]
@@ -11,21 +22,37 @@ permissions:
   contents: write
   pull-requests: read
 
+env:
+  # Final semver: vX.Y.Z. Prerelease: vX.Y.Z-<alphanum-or-dot>+
+  # The capture group returns the version WITHOUT the leading 'v' so
+  # downstream code can compare against pyproject.toml.
+  RELEASE_TITLE_RE: '(?:^|\s)release:\s*v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)(?:\s|$)'
+  RELEASE_LABEL_RE: '^release:v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)$'
+  VERSION_RE: '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
+
 jobs:
   validate-release-intent:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Validate semver release marker on PR to main
+      - name: Validate release marker on PR to main
         uses: actions/github-script@v7
+        env:
+          TITLE_RE: ${{ env.RELEASE_TITLE_RE }}
+          LABEL_RE: ${{ env.RELEASE_LABEL_RE }}
+          VERSION_RE: ${{ env.VERSION_RE }}
         with:
           script: |
             const title = context.payload.pull_request.title || "";
             const labels = (context.payload.pull_request.labels || []).map((l) => l.name);
 
-            const titleMatch = title.match(/(?:^|\s)release:\s*([0-9]+\.[0-9]+\.[0-9]+)(?:\s|$)/i);
+            const titleRe = new RegExp(process.env.TITLE_RE, "i");
+            const labelRe = new RegExp(process.env.LABEL_RE, "i");
+            const versionRe = new RegExp(process.env.VERSION_RE);
+
+            const titleMatch = title.match(titleRe);
             const labelMatches = labels
-              .map((name) => name.match(/^release:([0-9]+\.[0-9]+\.[0-9]+)$/i))
+              .map((name) => name.match(labelRe))
               .filter(Boolean);
 
             const versions = new Set();
@@ -34,7 +61,8 @@ jobs:
 
             if (versions.size !== 1) {
               core.setFailed(
-                "PRs targeting main must declare exactly one release version via title 'release: x.x.x' or label 'release:x.x.x'."
+                "PRs targeting main must declare exactly one release version via " +
+                "title 'release: vX.Y.Z[-suffix]' or label 'release:vX.Y.Z[-suffix]'."
               );
               return;
             }
@@ -42,25 +70,26 @@ jobs:
             const [version] = Array.from(versions);
             core.info(`Detected release version: ${version}`);
 
-            // Enforce clean x.x.x semantic version shape.
-            if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)) {
-              core.setFailed(`Invalid release version '${version}'. Expected x.x.x`);
+            if (!versionRe.test(version)) {
+              core.setFailed(`Invalid release version '${version}'. Expected X.Y.Z or X.Y.Z-suffix.`);
               return;
             }
 
-            // Ensure this version tag does not already exist.
+            const tagRef = `v${version}`;
             const { data: refs } = await github.rest.git.listMatchingRefs({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: `tags/${version}`,
+              ref: `tags/${tagRef}`,
             });
-            if (refs.length > 0) {
-              core.setFailed(`Tag '${version}' already exists. Choose a new version.`);
+            if (refs.some((r) => r.ref === `refs/tags/${tagRef}`)) {
+              core.setFailed(`Tag '${tagRef}' already exists. Choose a new version.`);
               return;
             }
 
+            const isPrerelease = version.includes("-");
             core.notice(
-              `Release version '${version}' validated. Merge to main will auto-tag the merge commit with this version.`
+              `Release version '${version}' validated (${isPrerelease ? "prerelease → TestPyPI" : "final → PyPI"}). ` +
+              `Merge to main will auto-tag the merge commit as '${tagRef}'.`
             );
 
   tag-main-commit:
@@ -69,11 +98,19 @@ jobs:
     steps:
       - name: Resolve release version from merged PR and create tag
         uses: actions/github-script@v7
+        env:
+          TITLE_RE: ${{ env.RELEASE_TITLE_RE }}
+          LABEL_RE: ${{ env.RELEASE_LABEL_RE }}
+          VERSION_RE: ${{ env.VERSION_RE }}
         with:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const sha = context.sha;
+
+            const titleRe = new RegExp(process.env.TITLE_RE, "i");
+            const labelRe = new RegExp(process.env.LABEL_RE, "i");
+            const versionRe = new RegExp(process.env.VERSION_RE);
 
             const pullsResp = await github.request(
               "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
@@ -82,7 +119,7 @@ jobs:
             const pulls = pullsResp.data || [];
             if (pulls.length === 0) {
               core.setFailed(
-                `No PR found for commit ${sha}. main requires PR-based release merges with semver markers.`
+                `No PR found for commit ${sha}. main requires PR-based release merges with release markers.`
               );
               return;
             }
@@ -91,9 +128,9 @@ jobs:
             const title = pr.title || "";
             const labels = (pr.labels || []).map((l) => l.name);
 
-            const titleMatch = title.match(/(?:^|\s)release:\s*([0-9]+\.[0-9]+\.[0-9]+)(?:\s|$)/i);
+            const titleMatch = title.match(titleRe);
             const labelMatches = labels
-              .map((name) => name.match(/^release:([0-9]+\.[0-9]+\.[0-9]+)$/i))
+              .map((name) => name.match(labelRe))
               .filter(Boolean);
 
             const versions = new Set();
@@ -102,31 +139,34 @@ jobs:
 
             if (versions.size !== 1) {
               core.setFailed(
-                `Merged PR #${pr.number} must contain exactly one release marker: title 'release: x.x.x' or label 'release:x.x.x'.`
+                `Merged PR #${pr.number} must contain exactly one release marker: ` +
+                `title 'release: vX.Y.Z[-suffix]' or label 'release:vX.Y.Z[-suffix]'.`
               );
               return;
             }
 
             const [version] = Array.from(versions);
-            if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)) {
-              core.setFailed(`Invalid release version '${version}'. Expected x.x.x`);
+            if (!versionRe.test(version)) {
+              core.setFailed(`Invalid release version '${version}'. Expected X.Y.Z or X.Y.Z-suffix.`);
               return;
             }
 
+            const tagRef = `v${version}`;
             const existing = await github.rest.git.listMatchingRefs({
               owner,
               repo,
-              ref: `tags/${version}`,
+              ref: `tags/${tagRef}`,
             });
 
-            if (existing.data.length > 0) {
-              const existingSha = existing.data[0]?.object?.sha;
+            const exact = existing.data.find((r) => r.ref === `refs/tags/${tagRef}`);
+            if (exact) {
+              const existingSha = exact.object?.sha;
               if (existingSha === sha) {
-                core.notice(`Tag '${version}' already points at ${sha}.`);
+                core.notice(`Tag '${tagRef}' already points at ${sha}.`);
                 return;
               }
               core.setFailed(
-                `Tag '${version}' already exists on ${existingSha}; refusing to retarget to ${sha}.`
+                `Tag '${tagRef}' already exists on ${existingSha}; refusing to retarget to ${sha}.`
               );
               return;
             }
@@ -134,10 +174,12 @@ jobs:
             await github.rest.git.createRef({
               owner,
               repo,
-              ref: `refs/tags/${version}`,
+              ref: `refs/tags/${tagRef}`,
               sha,
             });
 
+            const isPrerelease = version.includes("-");
             core.notice(
-              `Created release tag '${version}' for commit ${sha} from merged PR #${pr.number}.`
+              `Created release tag '${tagRef}' for commit ${sha} from merged PR #${pr.number}. ` +
+              `release-publish.yml will publish to ${isPrerelease ? "TestPyPI" : "PyPI"}.`
             );

--- a/.github/workflows/main-release-tag-gate.yml
+++ b/.github/workflows/main-release-tag-gate.yml
@@ -5,11 +5,13 @@ name: Main Release Tag Gate
 # (.github/workflows/release-publish.yml) listens for those tags and
 # routes finals to PyPI, prereleases to TestPyPI.
 #
-# Accepted release-marker syntaxes:
-#   PR title:  "release: v0.1.0" or "release: v0.1.0-rc1"
-#   PR label:  "release:v0.1.0"   or "release:v0.1.0-rc1"
+# Required release-marker syntax (the leading `v` is mandatory; the
+# bare `0.1.0` form is intentionally rejected so there is exactly one
+# canonical version representation):
+#   PR title:  "release: v0.1.0"   or  "release: v0.1.0-rc1"
+#   PR label:  "release:v0.1.0"     or  "release:v0.1.0-rc1"
 #
-# Created tag (always v-prefixed):  v0.1.0  /  v0.1.0-rc1
+# Created tag:  v0.1.0  /  v0.1.0-rc1
 
 on:
   pull_request:
@@ -23,11 +25,13 @@ permissions:
   pull-requests: read
 
 env:
-  # Final semver: vX.Y.Z. Prerelease: vX.Y.Z-<alphanum-or-dot>+
-  # The capture group returns the version WITHOUT the leading 'v' so
-  # downstream code can compare against pyproject.toml.
-  RELEASE_TITLE_RE: '(?:^|\s)release:\s*v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)(?:\s|$)'
-  RELEASE_LABEL_RE: '^release:v?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)$'
+  # Final: vX.Y.Z. Prerelease: vX.Y.Z-<alphanum-or-dot>+. The leading
+  # `v` is REQUIRED — bare `0.1.0` is rejected so the project carries
+  # exactly one canonical version string. The capture group returns
+  # the version without the leading 'v' so downstream code can compare
+  # against pyproject.toml directly.
+  RELEASE_TITLE_RE: '(?:^|\s)release:\s*v([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)(?:\s|$)'
+  RELEASE_LABEL_RE: '^release:v([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.]+)?)$'
   VERSION_RE: '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'
 
 jobs:
@@ -61,8 +65,10 @@ jobs:
 
             if (versions.size !== 1) {
               core.setFailed(
-                "PRs targeting main must declare exactly one release version via " +
-                "title 'release: vX.Y.Z[-suffix]' or label 'release:vX.Y.Z[-suffix]'."
+                "PRs targeting main must declare exactly one release version. " +
+                "Use a title like 'release: v0.1.0' (or 'release: v0.1.0-rc1' " +
+                "for a prerelease), or a label 'release:v0.1.0'. The leading " +
+                "`v` is required."
               );
               return;
             }
@@ -71,7 +77,7 @@ jobs:
             core.info(`Detected release version: ${version}`);
 
             if (!versionRe.test(version)) {
-              core.setFailed(`Invalid release version '${version}'. Expected X.Y.Z or X.Y.Z-suffix.`);
+              core.setFailed(`Invalid release version 'v${version}'. Expected vX.Y.Z or vX.Y.Z-suffix.`);
               return;
             }
 
@@ -139,15 +145,16 @@ jobs:
 
             if (versions.size !== 1) {
               core.setFailed(
-                `Merged PR #${pr.number} must contain exactly one release marker: ` +
-                `title 'release: vX.Y.Z[-suffix]' or label 'release:vX.Y.Z[-suffix]'.`
+                `Merged PR #${pr.number} must contain exactly one release marker — ` +
+                "title 'release: v0.1.0' (or 'release: v0.1.0-rc1' for a " +
+                "prerelease) or label 'release:v0.1.0'. The leading `v` is required."
               );
               return;
             }
 
             const [version] = Array.from(versions);
             if (!versionRe.test(version)) {
-              core.setFailed(`Invalid release version '${version}'. Expected X.Y.Z or X.Y.Z-suffix.`);
+              core.setFailed(`Invalid release version 'v${version}'. Expected vX.Y.Z or vX.Y.Z-suffix.`);
               return;
             }
 

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -1,0 +1,81 @@
+name: PR conventions
+
+# Enforces project conventions on PRs into dev and main:
+#
+#   1. Branch name MUST match  ^(feature|fix|chore)/[a-z0-9]+(-[a-z0-9]+)*$
+#      The release-tag branches (cursor/...) raised by CI agents are
+#      explicitly exempt because they're not human-authored.
+#
+#   2. PR body MUST reference an issue (e.g. 'Fixes #N', 'Closes #N',
+#      'Refs #N') unless the branch is a 'chore/...' branch (chores
+#      are housekeeping that doesn't need an issue) or the PR carries
+#      the 'no-issue-required' label (escape hatch for maintainer
+#      discretion).
+#
+# Documented in docs/contributor-guide.md.
+
+on:
+  pull_request:
+    branches: [dev, main]
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  branch-naming:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate branch name
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request?.head?.ref || "";
+            // Allow CI-agent branches (cursor/* and dependabot/*) and the
+            // release-tag-gate's auto-branches; humans must follow the
+            // feature|fix|chore prefix convention.
+            const exemptPrefixes = ["cursor/", "dependabot/", "ci/"];
+            if (exemptPrefixes.some((p) => branch.startsWith(p))) {
+              core.notice(`Branch '${branch}' is CI-managed; convention check skipped.`);
+              return;
+            }
+            const re = /^(feature|fix|chore)\/[a-z0-9]+(-[a-z0-9]+)*$/;
+            if (!re.test(branch)) {
+              core.setFailed(
+                `Branch name '${branch}' does not match the convention. ` +
+                `Use one of: feature/<kebab-description>, fix/<kebab-description>, ` +
+                `chore/<kebab-description>. See docs/contributor-guide.md.`
+              );
+              return;
+            }
+            core.notice(`Branch '${branch}' follows the naming convention.`);
+
+  issue-link:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require issue reference in PR body (with chore exemption)
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const branch = pr?.head?.ref || "";
+            const body = pr?.body || "";
+            const labels = (pr?.labels || []).map((l) => l.name);
+            // Chore PRs and explicitly-labelled PRs do not need an issue link.
+            if (branch.startsWith("chore/") || labels.includes("no-issue-required")) {
+              core.notice("Chore branch (or 'no-issue-required' label): issue link not required.");
+              return;
+            }
+            // Accept the GitHub-recognized closing keywords or a plain '#N' refs:.
+            const re = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)[:\s]+#\d+/i;
+            if (!re.test(body)) {
+              core.setFailed(
+                "Non-chore PRs must reference an issue in the body — e.g. " +
+                "'Fixes #123' or 'Refs #123'. Add the reference, or apply the " +
+                "'no-issue-required' label if a maintainer has approved an exception. " +
+                "See docs/contributor-guide.md."
+              );
+              return;
+            }
+            core.notice("Issue reference found in PR body.");

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,283 @@
+name: Release publish
+
+# Triggered by tags created by .github/workflows/main-release-tag-gate.yml
+# (which auto-tags merge commits on main from PRs carrying a 'release:'
+# marker). Routes finals (vX.Y.Z) to PyPI and prereleases (vX.Y.Z-suffix)
+# to TestPyPI via OIDC trusted publishing — no API tokens.
+#
+# Required setup (one-time, off-repo):
+#   - PyPI:     https://pypi.org/manage/account/publishing/
+#               trusted publisher: shanevigil/specy-road, workflow=release-publish.yml,
+#               environment=pypi
+#   - TestPyPI: https://test.pypi.org/manage/account/publishing/
+#               trusted publisher: shanevigil/specy-road, workflow=release-publish.yml,
+#               environment=testpypi
+#   - GitHub:   Settings -> Environments -> create 'pypi' (deployment tag rule
+#               'v[0-9]+.[0-9]+.[0-9]+'; required reviewer optional) and 'testpypi'
+#               (tag rule 'v[0-9]+.[0-9]+.[0-9]+-*'; no reviewers).
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    # Manual smoke trigger; uses 'v0.0.0-dev' as a fake tag so we can
+    # exercise the build/verify chain without publishing anything.
+    inputs:
+      dry_run:
+        description: 'Build only (skip publish + release).'
+        required: false
+        default: 'true'
+
+# Prevent two tag pushes from racing.
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: write       # creating GitHub Release + tag refs for follow-up PR
+  pull-requests: write  # opening the post-publish README cleanup PR
+  id-token: write       # OIDC -> PyPI trusted publishing
+  attestations: write   # sigstore PEP 740 provenance
+
+jobs:
+  # 1. Re-run the same gates the PR did before publishing the tagged commit.
+  validate:
+    name: Validate (reusable)
+    uses: ./.github/workflows/validate.yml
+
+  # 2. Resolve the version + intended target (PyPI / TestPyPI / dry-run).
+  resolve:
+    name: Resolve release context
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.ctx.outputs.tag }}
+      version: ${{ steps.ctx.outputs.version }}
+      pep440_version: ${{ steps.ctx.outputs.pep440_version }}
+      is_prerelease: ${{ steps.ctx.outputs.is_prerelease }}
+      target: ${{ steps.ctx.outputs.target }}
+      dry_run: ${{ steps.ctx.outputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Compute release context
+        id: ctx
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="v0.0.0-dev"
+            dry="${{ github.event.inputs.dry_run }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+            dry="false"
+          fi
+          version="${tag#v}"
+          # Convert X.Y.Z-rc1 -> X.Y.Zrc1 for PEP 440 comparison.
+          pep440_version="$(echo "${version}" | sed -E 's/^([0-9]+\.[0-9]+\.[0-9]+)-([A-Za-z]+[0-9]*)$/\1\2/')"
+          if [[ "${version}" == *-* ]]; then
+            is_prerelease="true"
+            target="testpypi"
+          else
+            is_prerelease="false"
+            target="pypi"
+          fi
+          if [[ "${dry}" == "true" ]]; then
+            target="dry-run"
+          fi
+          echo "tag=${tag}"               | tee -a "${GITHUB_OUTPUT}"
+          echo "version=${version}"       | tee -a "${GITHUB_OUTPUT}"
+          echo "pep440_version=${pep440_version}" | tee -a "${GITHUB_OUTPUT}"
+          echo "is_prerelease=${is_prerelease}"   | tee -a "${GITHUB_OUTPUT}"
+          echo "target=${target}"         | tee -a "${GITHUB_OUTPUT}"
+          echo "dry_run=${dry}"           | tee -a "${GITHUB_OUTPUT}"
+
+  # 3. Build sdist + wheel; verify pyproject version + wheel contents.
+  build:
+    name: Build distribution
+    needs: [validate, resolve]
+    runs-on: ubuntu-latest
+    outputs:
+      sdist_name: ${{ steps.find.outputs.sdist_name }}
+      wheel_name: ${{ steps.find.outputs.wheel_name }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: gui/pm-gantt/package-lock.json
+      - name: Install build deps
+        run: |
+          python -m pip install --upgrade 'pip>=25.3' build
+      - name: Build PM Gantt SPA (npm)
+        working-directory: gui/pm-gantt
+        run: |
+          npm ci
+          npm run build
+      - name: Verify SPA bundled into the package tree
+        run: test -f specy_road/pm_gantt_static/index.html
+      - name: Verify pyproject version matches tag
+        run: python scripts/check_release_version.py "${{ needs.resolve.outputs.tag }}"
+      - name: Build sdist + wheel
+        run: python -m build
+      - name: Verify wheel contains PM Gantt UI assets
+        run: |
+          set -euo pipefail
+          wheel="$(ls dist/*.whl)"
+          python scripts/verify_wheel_contents.py "${wheel}"
+      - name: Capture artifact names
+        id: find
+        run: |
+          sdist=$(basename "$(ls dist/*.tar.gz)")
+          wheel=$(basename "$(ls dist/*.whl)")
+          echo "sdist_name=${sdist}" | tee -a "${GITHUB_OUTPUT}"
+          echo "wheel_name=${wheel}" | tee -a "${GITHUB_OUTPUT}"
+      - name: Smoke-install the wheel in a fresh venv
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --upgrade 'pip>=25.3'
+          /tmp/smoke/bin/pip install dist/*.whl
+          /tmp/smoke/bin/specy-road --help
+          /tmp/smoke/bin/specy-road validate --repo-root tests/fixtures/specy_road_dogfood
+          /tmp/smoke/bin/specy-road export --check --repo-root tests/fixtures/specy_road_dogfood
+      - name: Upload built distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: dist/*
+
+  # 4a. Publish to TestPyPI (prereleases only).
+  publish-testpypi:
+    name: Publish to TestPyPI
+    if: needs.resolve.outputs.target == 'testpypi'
+    needs: [build, resolve]
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/specy-road
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist
+      - name: Publish to TestPyPI (OIDC trusted publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true
+
+  # 4b. Publish to PyPI (finals only). The 'pypi' GitHub environment can
+  # require a human reviewer; that is configured in repo Settings, not here.
+  publish-pypi:
+    name: Publish to PyPI
+    if: needs.resolve.outputs.target == 'pypi'
+    needs: [build, resolve]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/specy-road
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist
+      - name: Publish to PyPI (OIDC trusted publisher)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true
+
+  # 5. After a successful publish (PyPI or TestPyPI), create a GitHub
+  # Release with the changelog section as the body and the artifacts
+  # attached. Skipped on dry-run.
+  github-release:
+    name: GitHub Release
+    needs: [resolve, build, publish-testpypi, publish-pypi]
+    # always() so this runs even though one of the two publish jobs was
+    # skipped by its `if`; succeed only when at least one publish landed.
+    if: ${{ always() && needs.resolve.outputs.target != 'dry-run' && (needs.publish-pypi.result == 'success' || needs.publish-testpypi.result == 'success') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v6
+        with:
+          name: dist
+          path: dist
+      - name: Extract changelog section
+        id: notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${{ needs.resolve.outputs.tag }}"
+          # Extract the section under '## [<tag>]' up to the next '## [' heading.
+          if [[ -f CHANGELOG.md ]]; then
+            awk -v target="## [${tag}]" '
+              $0 ~ "^## \\[" {
+                if ($0 ~ "^## \\[" target "\\]" || index($0, target) == 1) { capture=1; next }
+                else if (capture) { exit }
+              }
+              capture { print }
+            ' CHANGELOG.md > /tmp/release-notes.md
+          fi
+          if [[ ! -s /tmp/release-notes.md ]]; then
+            printf "Release %s — see CHANGELOG.md for details.\n" "${tag}" > /tmp/release-notes.md
+          fi
+          {
+            echo 'body<<__NOTES_EOF__'
+            cat /tmp/release-notes.md
+            echo '__NOTES_EOF__'
+          } >> "${GITHUB_OUTPUT}"
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve.outputs.tag }}
+          name: ${{ needs.resolve.outputs.tag }}
+          body: ${{ steps.notes.outputs.body }}
+          prerelease: ${{ needs.resolve.outputs.is_prerelease == 'true' }}
+          files: dist/*
+
+  # 6. After the FIRST PyPI publish, open a follow-up PR that strips the
+  # README pre-release notice + TODO comment + swaps the install-from-
+  # source block with a real `pip install specy-road`. Only fires for
+  # finals (the prerelease run does not edit the README).
+  followup-readme-cleanup:
+    name: Open follow-up README cleanup PR
+    if: needs.resolve.outputs.target == 'pypi' && needs.publish-pypi.result == 'success'
+    needs: [resolve, publish-pypi]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 0
+      - name: Strip pre-release notice + TODO; swap install block
+        id: edit
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/post_release_readme_cleanup.py "${{ needs.resolve.outputs.version }}"
+      - name: Open follow-up PR if README changed
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/readme-post-release-${{ needs.resolve.outputs.version }}
+          base: dev
+          title: 'chore(readme): post-release cleanup for v${{ needs.resolve.outputs.version }}'
+          body: |
+            Auto-opened by `release-publish.yml` after the successful
+            PyPI publish of `v${{ needs.resolve.outputs.version }}`.
+
+            Removes the pre-release notice block and the
+            `TODO(post-release)` comment from `README.md`, and swaps the
+            install-from-source block for the standard
+            `pip install specy-road` instructions.
+
+            Review and merge to `dev`; the next release PR will pick
+            this up automatically.
+          commit-message: 'chore(readme): post-release cleanup for v${{ needs.resolve.outputs.version }}'
+          delete-branch: true
+          draft: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,10 +1,14 @@
 name: Validate roadmap
 
+# This workflow doubles as a reusable pipeline. The release-publish
+# workflow calls it via `uses: ./.github/workflows/validate.yml` so a
+# tag-driven release re-runs the same gates the PR did before publish.
 on:
   push:
     branches: [main, dev]
   pull_request:
     branches: [main, dev]
+  workflow_call:
 
 jobs:
   roadmap:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The release-publish workflow extracts the section for the release tag
+(matched by `## [vX.Y.Z]` heading) and uses it as the GitHub Release
+body. Keep section bodies focused; link to PRs for detail.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
+## [v0.1.0-rc1] - TBD
+
+First public release candidate. Published to TestPyPI for rehearsal.
+v0.1.0 will follow on PyPI once a smoke install / smoke run confirms
+the package wheel is correct.
+
+### Added
+
+- Roadmap-first coordination kit: scaffold (`specy-road init project`),
+  validate, export, brief, the dev pickup loop
+  (`do-next-available-task` / `mark-implementation-reviewed` /
+  `finish-this-task`), and the PM Gantt FastAPI + React UI
+  (`specy-road gui`).
+- Auto-derive codenames from titles (with collision suffix from the
+  node UUID); validate self-heals codenames and strips deprecated
+  fields. Tasks created via `add-node` are pickup-eligible by
+  default. (F-006, F-008)
+- Comprehensive `specy-road brief`: a deterministic 7-section
+  work-packet that inlines all relevant planning sheets and shared
+  contracts so an implementing agent has everything in one document.
+  (F-004)
+- PR-body snapshot: when finishing a task with `--on-complete pr` (or
+  `auto`), `finish-this-task` writes `work/pr-body-<NODE>.md`
+  containing the dev-authored implementation summary plus the
+  work-packet brief. The printed `gh pr create` / `glab mr create`
+  command already references it via `--body-file` /
+  `--description-file`. Snapshot semantics: the body does not
+  auto-update if the roadmap evolves later. (F-015)
+- PR-gating for downstream tasks when `on_complete: pr`: a leaf whose
+  dependency has been picked up but whose PR has not yet merged is
+  blocked from selection. (F-007)
+- Self-heal stale registry claims: if `do-next-available-task` fails
+  after registering a claim but before creating the feature branch,
+  the claim is auto-rolled-back; if the rollback also fails, a
+  structured warning names the node and the recovery command. (F-014)
+- Computed ancestor `rollup_status`: a non-leaf is `Complete` only
+  when every leaf descendant is. The CLI export, the JSON API, and
+  the PM Gantt UI all read the same computed value; the API
+  substitutes `status` with `rollup_status` on the wire so the
+  prebuilt React bundle shows correct rollups without a rebuild.
+  (F-013)
+- Auto-stash work/ around the integration-branch registry commit
+  (`do-next-available-task` and `mark-implementation-reviewed`) so
+  the registry mutation lands alone, not polluted with feature-branch
+  artifacts. (F-011)
+- Consumer scaffold ships a `.gitignore` covering session-only files.
+  (F-011)
+
+### Changed
+
+- `validate` is now a self-healing utility (silent fixes for missing
+  codenames + deprecated-field scrubbing); `do-next-available-task`
+  runs `validate` before pickup.
+- `finish-this-task --on-complete merge` actually merges the feature
+  branch into the integration branch and pushes; clear error if the
+  integration branch ref is missing rather than a silent fall-through
+  to PR instructions. (F-012)
+- Touch zones are optional. The brief instructs the implementing
+  agent to discover or confirm them via codebase scan if missing.
+  (F-009)
+- README: pre-release notice + `pip install` from-source steps until
+  v0.1.0 ships. (F-001)
+- Docs: consolidated three install-overlapping guides into
+  `docs/install-and-usage.md` (end-user) and `docs/contributor-guide.md`
+  (release process, branching, tagging, contributors). Removed
+  `docs/setup.md`. (F-002)
+
+### Removed
+
+- `execution_subtask` and `agentic_checklist` fields. All leaf tasks
+  are agentic by design; the schema, CRUD CLI, validate, brief, and
+  export no longer reference them. Validate auto-strips them from
+  any consumer roadmap that still has them. (F-003, F-007)
+- `--no-git` flag from `specy-road sync`. Git with a configured
+  remote is a hard dependency; the docs document the local-bare-remote
+  pattern for purely-local trials. (F-010)
+- `validate`'s warning about missing `origin/main` ref. specy-road
+  only cares that `integration_branch` is declared; the rest is the
+  user's git hygiene. (F-005)
+
+[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.0-rc1...HEAD
+[v0.1.0-rc1]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc1

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -111,6 +111,8 @@ Semver tags with a `v` prefix:
 
 You **don't tag manually**. Instead, open a PR from `dev` to `main` with
 the title `release: v0.1.0` (or apply the `release:v0.1.0` label). The
+leading `v` is **required** — the bare `0.1.0` form is rejected so the
+project carries exactly one canonical version representation. The
 [main-release-tag-gate.yml](../.github/workflows/main-release-tag-gate.yml)
 workflow:
 
@@ -130,7 +132,8 @@ workflow:
 2. Update `CHANGELOG.md` — add a `## [vX.Y.Z]` section with the body
    that should appear on the GitHub Release.
 3. Open a release PR from `dev` to `main` with title
-   `release: vX.Y.Z`. Body explains what's in the release.
+   `release: vX.Y.Z` (the leading `v` is required). Body explains what's
+   in the release.
 4. Get the PR reviewed; merge it.
 
 **Machines (no further human action required):**

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -11,6 +11,62 @@ own application repos) should read
 
 ---
 
+## Project stewardship
+
+`specy-road` is maintained by [@shanevigil](https://github.com/shanevigil).
+The maintainer reserves the **right of refusal**: any PR may be closed
+for any reason, with or without explanation. Out-of-scope changes,
+contested architecture, undisclosed conflicts of interest, or low-effort
+contributions are all valid grounds for closure. Don't take it
+personally; it's a small project and direction matters.
+
+### Issues come first
+
+Before opening a non-trivial PR, **open or reference an existing
+issue**. The PR body must include a closing-keyword link:
+
+```
+Closes #123
+Fixes #45
+Refs #67
+```
+
+This is enforced by [`pr-conventions.yml`](../.github/workflows/pr-conventions.yml).
+Two exemptions exist:
+
+1. **`chore/<...>` branches** — housekeeping (typo fixes, lint cleanup,
+   doc tidying, dependency bumps) does not require an issue.
+2. **The `no-issue-required` label** — applied at the maintainer's
+   discretion when a contribution warrants an exception (e.g. emergency
+   security fix).
+
+### Malicious code policy
+
+specy-road is a coordination tool that runs on contributor laptops and
+in CI environments. Any pull request found to contain **malicious code**
+— including but not limited to: cryptominers, data-exfiltration shims,
+backdoor commits, supply-chain attacks (typosquatting in
+`requirements-ci.txt` or `package-lock.json`, lockfile substitution,
+post-install hooks that fetch arbitrary code, tampering with the
+trusted-publisher config, attempts to weaken the validate / file-limits
+/ audit pipeline) — will result in:
+
+1. Immediate closure of the PR.
+2. Permanent ban of the contributor from this repository.
+3. **Reporting** to GitHub Trust & Safety
+   (`https://github.com/contact/report-abuse`) and, where applicable,
+   to PyPI (security@pypi.org), npm (security@npmjs.com), CISA, and
+   any downstream consumer the maintainer can identify.
+4. Public audit-trail preservation — the offending commits and PR
+   metadata remain available so other maintainers can recognize the
+   pattern.
+
+By submitting a PR you accept this policy. If you spot suspicious
+activity in someone else's PR, please report it privately to the
+maintainer rather than commenting publicly on the PR thread.
+
+---
+
 ## Branching, tagging, and release process
 
 ### Default branch is `dev`
@@ -18,48 +74,117 @@ own application repos) should read
 - All feature work targets **`dev`**.
 - The **`main`** branch is reserved for tagged releases. The
   [`main-release-tag-gate.yml`](../.github/workflows/main-release-tag-gate.yml)
-  workflow rejects pushes to `main` that aren't annotated tags.
-- `main` is intentionally minimal (README + the gate workflow) until v0.1.
+  workflow rejects pushes to `main` that aren't release-marker PRs and
+  auto-tags merge commits.
+- `main` is intentionally minimal (README + workflows) until v0.1.
 
-### Feature branches
+### Branch-naming convention (enforced)
 
-Use `feature/<short-slug>` off `dev` for changes that aren't a roadmap
-node, and `feature/refine_<area>` for sweeping refactors.
+Branch names **must** match one of these prefixes followed by a kebab-case
+description:
 
-For roadmap-driven work picked up via `specy-road do-next-available-task`,
-the CLI creates `feature/rm-<codename>` automatically and registers the
-claim on the integration branch first. See
-[git-workflow.md](git-workflow.md) for the full ceremony (registry rows,
-touch zones, PR vs merge, etc.).
+```
+feature/<kebab-description>     # new functionality
+fix/<kebab-description>          # bug fix
+chore/<kebab-description>        # housekeeping (no issue link required)
+```
+
+The regex enforced by
+[`pr-conventions.yml`](../.github/workflows/pr-conventions.yml) is:
+
+```
+^(feature|fix|chore)/[a-z0-9]+(-[a-z0-9]+)*$
+```
+
+CI-managed branches (`cursor/...`, `dependabot/...`, `ci/...`) are
+exempt. Roadmap-driven `feature/rm-<codename>` branches created by
+`specy-road do-next-available-task` automatically satisfy the
+`feature/...` prefix.
 
 ### Tagging convention
 
-Semver: `vMAJOR.MINOR.PATCH` (e.g. `v0.1.0`, `v0.2.0-rc1`). Tags are cut
-from `dev` and merged to `main`. The `main-release-tag-gate.yml` workflow
-verifies the tag matches `v\d+\.\d+\.\d+(-[A-Za-z0-9.]+)?`.
+Semver tags with a `v` prefix:
 
-### PR workflow
+- Final releases: `v0.1.0`, `v1.2.3`.
+- Pre-releases: `v0.1.0-rc1`, `v0.2.0-beta1`. PEP 440 normalization is
+  handled automatically (`-rc1` ↔ `rc1`).
 
-- Open PRs against `dev`. Drafts welcome.
-- Keep PRs small and focused — one cluster of related findings or one
-  feature.
-- Squash on merge unless the commit history is meaningful (rare).
-- Every PR should keep `pytest -q`, `specy-road validate`,
-  `specy-road export --check`, and `specy-road file-limits` green
-  against `tests/fixtures/specy_road_dogfood/`.
+You **don't tag manually**. Instead, open a PR from `dev` to `main` with
+the title `release: v0.1.0` (or apply the `release:v0.1.0` label). The
+[main-release-tag-gate.yml](../.github/workflows/main-release-tag-gate.yml)
+workflow:
 
-### Release process
+1. Validates the marker on the PR.
+2. On merge to `main`, auto-creates the `vX.Y.Z` tag at the merge
+   commit.
+3. The tag push triggers
+   [release-publish.yml](../.github/workflows/release-publish.yml),
+   which publishes to PyPI (final tags) or TestPyPI (prerelease tags)
+   via OIDC trusted publishing.
 
-1. Land all required PRs on `dev`.
-2. Run the full local check (see *Local CI parity* below).
-3. Cut a tag: `git tag -a v0.1.0 -m "v0.1.0"` from `dev`'s tip.
-4. Merge `dev` into `main` (fast-forward) and push the tag.
-5. **TODO (post-release):** automate PyPI build-and-publish on every
-   tagged release. The README's top-of-file `TODO(post-release)` comment
-   tracks this.
+### Automated release process (what humans do, what machines do)
 
-Until PyPI publish is automated, the canonical way to install is from
-source on the `dev` branch (see [install-and-usage.md](install-and-usage.md)).
+**Humans:**
+
+1. Bump `pyproject.toml`'s `project.version` on `dev`.
+2. Update `CHANGELOG.md` — add a `## [vX.Y.Z]` section with the body
+   that should appear on the GitHub Release.
+3. Open a release PR from `dev` to `main` with title
+   `release: vX.Y.Z`. Body explains what's in the release.
+4. Get the PR reviewed; merge it.
+
+**Machines (no further human action required):**
+
+5. `main-release-tag-gate.yml` validates the marker and (on merge)
+   creates the tag `vX.Y.Z` on the merge commit.
+6. `release-publish.yml` is triggered by the tag push and:
+   - Reuses [`validate.yml`](../.github/workflows/validate.yml) as a
+     prereq job to re-run the full validation pipeline against the
+     tagged commit.
+   - Builds sdist + wheel; runs
+     [`scripts/check_release_version.py`](../scripts/check_release_version.py)
+     to assert pyproject's version matches the tag.
+   - Runs
+     [`scripts/verify_wheel_contents.py`](../scripts/verify_wheel_contents.py)
+     to assert the wheel contains the bundled PM Gantt UI assets.
+   - Smoke-installs the wheel in a fresh venv and runs
+     `specy-road --help` + `validate` + `export --check` against
+     the dogfood fixture.
+   - Publishes to **TestPyPI** (prerelease tags) or **PyPI** (final
+     tags) via OIDC trusted publishing — no API tokens. Sigstore
+     attestations are emitted (PEP 740).
+   - Creates a GitHub Release using the `## [vX.Y.Z]` section of
+     `CHANGELOG.md` as the body, with the sdist + wheel attached.
+   - On the **first PyPI publish only**, opens a follow-up PR
+     (`chore/readme-post-release-X.Y.Z`) that strips the README's
+     pre-release notice + TODO and swaps the install-from-source
+     block for `pip install specy-road`.
+
+The PyPI Trusted Publisher OIDC trust is bound to **this exact workflow
+file** (`release-publish.yml`) and **these exact environments**
+(`pypi` and `testpypi`). Renaming the file or environments will break
+publishing until you update the trust on `pypi.org` and
+`test.pypi.org`.
+
+### Trust & environment setup (one-time, off-repo)
+
+1. **PyPI:** at `https://pypi.org/manage/account/publishing/` add a
+   pending trusted publisher with owner `shanevigil`, repo `specy-road`,
+   workflow `release-publish.yml`, environment `pypi`.
+2. **TestPyPI:** same thing at
+   `https://test.pypi.org/manage/account/publishing/` with environment
+   `testpypi`.
+3. **GitHub:** Settings → Environments → create `pypi` (deployment tag
+   rule `v[0-9]+.[0-9]+.[0-9]+`; required reviewer optional but
+   recommended) and `testpypi` (tag rule
+   `v[0-9]+.[0-9]+.[0-9]+-*`; no reviewers).
+
+### Manual smoke (no publish)
+
+The release workflow accepts a `workflow_dispatch` trigger with
+`dry_run: true`. This builds the package and runs all verification but
+does NOT publish or create a release. Useful when refactoring the
+workflow itself.
 
 ---
 

--- a/scripts/check_release_version.py
+++ b/scripts/check_release_version.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Verify pyproject.toml version matches a release tag.
+
+Usage:
+    python scripts/check_release_version.py <tag>
+
+Where <tag> is like ``v0.1.0`` or ``v0.1.0-rc1``. Strips the leading
+``v`` and compares against ``project.version`` in ``pyproject.toml``.
+
+Exit 0 on match, 1 on mismatch (prints both values).
+
+Used by .github/workflows/release-publish.yml.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+def read_pyproject_version(repo_root: Path) -> str:
+    pyproject = repo_root / "pyproject.toml"
+    if not pyproject.is_file():
+        raise SystemExit(f"error: pyproject.toml not found at {pyproject}")
+    with pyproject.open("rb") as f:
+        data = tomllib.load(f)
+    project = data.get("project", {})
+    version = project.get("version")
+    if not isinstance(version, str) or not version.strip():
+        raise SystemExit("error: project.version missing or empty in pyproject.toml")
+    return version.strip()
+
+
+def normalize_tag(tag: str) -> str:
+    """Strip ``refs/tags/`` and ``v`` prefixes from a tag ref."""
+    t = tag.strip()
+    if t.startswith("refs/tags/"):
+        t = t[len("refs/tags/"):]
+    if t.startswith("v"):
+        t = t[1:]
+    return t
+
+
+# PEP 440 prerelease normalization: tags use 'v0.1.0-rc1' (Git-friendly),
+# but PyPI/pyproject use '0.1.0rc1' (no dash). Normalize the tag form to
+# the pyproject form for comparison so contributors can write either.
+_PRERELEASE_RE = re.compile(r"^([0-9]+\.[0-9]+\.[0-9]+)-([A-Za-z]+[0-9]*)$")
+
+
+def normalize_for_pep440(version: str) -> str:
+    """Convert ``X.Y.Z-rc1`` -> ``X.Y.Zrc1`` (PEP 440); pass through otherwise."""
+    m = _PRERELEASE_RE.match(version)
+    if m:
+        return f"{m.group(1)}{m.group(2)}"
+    return version
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_release_version.py <tag>", file=sys.stderr)
+        return 2
+    tag = argv[1]
+    expected = normalize_for_pep440(normalize_tag(tag))
+    actual = read_pyproject_version(Path.cwd())
+    if expected == actual:
+        print(f"ok: pyproject version {actual!r} matches tag {tag!r}")
+        return 0
+    print(
+        f"error: pyproject version {actual!r} does NOT match tag {tag!r} "
+        f"(expected pyproject version to be {expected!r}, normalized to "
+        "PEP 440). Bump pyproject.toml's project.version to match the tag, "
+        "then re-tag the release commit.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/post_release_readme_cleanup.py
+++ b/scripts/post_release_readme_cleanup.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Strip the README pre-release notice + TODO + swap install block.
+
+Run after the FIRST PyPI publish of a final release (v0.1.0+). Mutates
+README.md in place. Idempotent: re-running is a no-op.
+
+Usage:
+    python scripts/post_release_readme_cleanup.py <version>
+
+The release-publish workflow calls this from a checkout of `dev`,
+then opens a PR with the resulting changes.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+README = Path("README.md")
+
+PRE_RELEASE_BLOCK_RE = re.compile(
+    r"\n> ## ⚠️ Pre-release notice\n(?:> .*\n)*\n",
+    re.MULTILINE,
+)
+
+TODO_COMMENT_RE = re.compile(
+    r"<!--\s*\n?TODO\(post-release\):.*?-->\s*\n*",
+    re.DOTALL,
+)
+
+INSTALL_BLOCK_OLD_RE = re.compile(
+    r"## Install\n\n.*?```bash\n"
+    r"git clone https://github\.com/shanevigil/specy-road\.git\n.*?```\n",
+    re.DOTALL,
+)
+
+INSTALL_BLOCK_NEW = """## Install
+
+Requires **Python 3.11+** and **git** (with a configured remote — `origin`
+by default).
+
+```bash
+pip install specy-road
+# optional extras:
+#   pip install "specy-road[gui-next]"  # PM Gantt UI deps
+#   pip install "specy-road[review]"    # LLM review (`specy-road review-node`)
+```
+
+The full install + everyday usage guide is at
+**[docs/install-and-usage.md](docs/install-and-usage.md)**. Building from
+source is documented in
+**[docs/contributor-guide.md](docs/contributor-guide.md)**.
+"""
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: post_release_readme_cleanup.py <version>", file=sys.stderr)
+        return 2
+    version = argv[1]
+    if not README.is_file():
+        print(f"error: {README} not found", file=sys.stderr)
+        return 1
+
+    original = README.read_text(encoding="utf-8")
+    text = original
+
+    # 1. Strip the pre-release blockquote, if present.
+    text = PRE_RELEASE_BLOCK_RE.sub("\n", text)
+
+    # 2. Strip the TODO(post-release) HTML comment at the top.
+    text = TODO_COMMENT_RE.sub("", text)
+
+    # 3. Replace the install block.
+    if INSTALL_BLOCK_OLD_RE.search(text):
+        text = INSTALL_BLOCK_OLD_RE.sub(INSTALL_BLOCK_NEW, text)
+
+    # 4. Collapse any leading blank lines that resulted from stripping.
+    text = re.sub(r"^\s+", "", text)
+    if not text.endswith("\n"):
+        text += "\n"
+
+    if text == original:
+        print(f"ok: README already cleaned (idempotent); no changes for v{version}.")
+        return 0
+
+    README.write_text(text, encoding="utf-8")
+    print(f"ok: README post-release cleanup applied for v{version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/verify_wheel_contents.py
+++ b/scripts/verify_wheel_contents.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Verify a built specy-road wheel contains the bundled PM Gantt UI.
+
+Usage:
+    python scripts/verify_wheel_contents.py <wheel.whl>
+
+Specifically asserts that ``specy_road/pm_gantt_static/index.html`` and
+at least one ``specy_road/pm_gantt_static/assets/index-*.js`` chunk are
+present inside the wheel. Catches the failure mode where the npm build
+step was skipped or returned an empty bundle and we'd otherwise ship a
+wheel with a broken ``specy-road gui``.
+
+Exit 0 on success, 1 with a clear message on failure.
+"""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+
+REQUIRED_FILES = (
+    "specy_road/pm_gantt_static/index.html",
+)
+REQUIRED_GLOBS = (
+    "specy_road/pm_gantt_static/assets/index-",  # prefix match on at least one entry
+)
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: verify_wheel_contents.py <wheel.whl>", file=sys.stderr)
+        return 2
+    wheel = Path(argv[1])
+    if not wheel.is_file():
+        print(f"error: wheel not found at {wheel}", file=sys.stderr)
+        return 1
+    with zipfile.ZipFile(wheel) as zf:
+        names = set(zf.namelist())
+
+    missing = [p for p in REQUIRED_FILES if p not in names]
+    for prefix in REQUIRED_GLOBS:
+        if not any(n.startswith(prefix) for n in names):
+            missing.append(f"{prefix}*")
+    if missing:
+        print(
+            "error: wheel is missing required PM Gantt UI assets:\n  "
+            + "\n  ".join(missing)
+            + "\n\nThis usually means the npm build step (npm run build "
+              "in gui/pm-gantt/) was skipped or produced no output. Re-build "
+              "the SPA and rebuild the wheel before publishing.",
+            file=sys.stderr,
+        )
+        return 1
+    print(
+        f"ok: wheel {wheel.name} contains PM Gantt UI assets "
+        f"(index.html + at least one index-*.js chunk)."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_check_release_version.py
+++ b/tests/test_check_release_version.py
@@ -1,0 +1,80 @@
+"""Unit tests for scripts/check_release_version.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "check_release_version.py"
+
+
+def _run(tag: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), tag],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _seed_pyproject(tmp_path: Path, version: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        f"""[project]
+name = "specy-road"
+version = "{version}"
+""",
+        encoding="utf-8",
+    )
+
+
+def test_matches_plain_version(tmp_path: Path) -> None:
+    _seed_pyproject(tmp_path, "0.1.0")
+    r = _run("v0.1.0", tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "matches tag" in r.stdout
+
+
+def test_matches_prerelease_with_pep440_normalization(tmp_path: Path) -> None:
+    """Tags use 'v0.1.0-rc1' (Git-friendly); pyproject uses '0.1.0rc1' (PEP 440)."""
+    _seed_pyproject(tmp_path, "0.1.0rc1")
+    r = _run("v0.1.0-rc1", tmp_path)
+    assert r.returncode == 0, r.stderr
+
+
+def test_pyproject_with_dash_form_is_rejected(tmp_path: Path) -> None:
+    """pyproject must use PEP 440 prerelease form ('0.1.0rc1', no dash)."""
+    _seed_pyproject(tmp_path, "0.1.0-rc1")
+    r = _run("v0.1.0-rc1", tmp_path)
+    assert r.returncode == 1
+    assert "does NOT match" in r.stderr
+
+
+def test_mismatch_returns_nonzero(tmp_path: Path) -> None:
+    _seed_pyproject(tmp_path, "0.1.0")
+    r = _run("v0.2.0", tmp_path)
+    assert r.returncode == 1
+    assert "does NOT match" in r.stderr
+
+
+def test_strips_refs_tags_prefix(tmp_path: Path) -> None:
+    _seed_pyproject(tmp_path, "0.1.0")
+    r = _run("refs/tags/v0.1.0", tmp_path)
+    assert r.returncode == 0, r.stderr
+
+
+def test_missing_pyproject_errors(tmp_path: Path) -> None:
+    r = _run("v0.1.0", tmp_path)
+    assert r.returncode != 0
+    assert "pyproject.toml not found" in r.stderr
+
+
+def test_missing_version_errors(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "specy-road"\n', encoding="utf-8"
+    )
+    r = _run("v0.1.0", tmp_path)
+    assert r.returncode != 0
+    assert "project.version missing" in r.stderr

--- a/tests/test_post_release_readme_cleanup.py
+++ b/tests/test_post_release_readme_cleanup.py
@@ -1,0 +1,106 @@
+"""Unit tests for scripts/post_release_readme_cleanup.py."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "post_release_readme_cleanup.py"
+
+
+def _run(version: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), version],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _seed(tmp_path: Path, body: str) -> Path:
+    out = tmp_path / "README.md"
+    out.write_text(body, encoding="utf-8")
+    return out
+
+
+def test_strips_pre_release_block_and_todo(tmp_path: Path) -> None:
+    body = """<!--
+TODO(post-release): wire automated PyPI build-and-publish on every tagged
+release (v*.*.*), then replace the install-from-source block below with a
+single `pip install specy-road` line.
+-->
+
+# specy-road
+
+> ## ⚠️ Pre-release notice
+> The first tagged release is pending. **There is no `specy-road` package on
+> PyPI yet.** Install from source as shown in the [Install](#install) section
+> until v0.1 ships.
+
+**Roadmap-first coordination** for teams and coding agents.
+
+## Install
+
+Requires **Python 3.11+** and **git** (with a configured remote — `origin` by
+default).
+
+```bash
+git clone https://github.com/shanevigil/specy-road.git
+cd specy-road
+git switch dev
+pip install -e ".[dev,gui-next]"
+```
+
+How the PM Gantt UI is packaged: see other docs.
+"""
+    _seed(tmp_path, body)
+    r = _run("0.1.0", tmp_path)
+    assert r.returncode == 0, r.stderr
+    new = (tmp_path / "README.md").read_text(encoding="utf-8")
+    # TODO comment gone.
+    assert "TODO(post-release)" not in new
+    # Pre-release blockquote gone.
+    assert "Pre-release notice" not in new
+    # New install block.
+    assert "pip install specy-road" in new
+    assert "git clone" not in new
+
+
+def test_idempotent_on_already_clean_readme(tmp_path: Path) -> None:
+    """Running twice (or on a clean README) is a no-op."""
+    body = """# specy-road
+
+A clean README without the pre-release scaffolding.
+
+## Install
+
+```bash
+pip install specy-road
+```
+"""
+    _seed(tmp_path, body)
+    r1 = _run("0.1.0", tmp_path)
+    text_after_first = (tmp_path / "README.md").read_text(encoding="utf-8")
+    r2 = _run("0.1.0", tmp_path)
+    text_after_second = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert r1.returncode == 0
+    assert r2.returncode == 0
+    # No-op the second time.
+    assert text_after_first == text_after_second
+
+
+def test_real_readme_smoke(tmp_path: Path) -> None:
+    """Smoke test against the actual repo README — verify it cleans without crash."""
+    src = REPO / "README.md"
+    dst = tmp_path / "README.md"
+    shutil.copy2(src, dst)
+    r = _run("0.1.0", tmp_path)
+    assert r.returncode == 0, r.stderr
+    new = dst.read_text(encoding="utf-8")
+    assert "TODO(post-release)" not in new
+    assert "Pre-release notice" not in new
+    assert "pip install specy-road" in new

--- a/tests/test_verify_wheel_contents.py
+++ b/tests/test_verify_wheel_contents.py
@@ -1,0 +1,67 @@
+"""Unit tests for scripts/verify_wheel_contents.py."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "verify_wheel_contents.py"
+
+
+def _make_wheel(path: Path, members: dict[str, str]) -> None:
+    """Build a tiny zip-shaped 'wheel' with the named members."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, content in members.items():
+            zf.writestr(name, content)
+
+
+def _run(wheel: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(wheel)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_passes_with_required_assets(tmp_path: Path) -> None:
+    wheel = tmp_path / "specy_road-0.1.0-py3-none-any.whl"
+    _make_wheel(wheel, {
+        "specy_road/__init__.py": "",
+        "specy_road/pm_gantt_static/index.html": "<!doctype html>",
+        "specy_road/pm_gantt_static/assets/index-abc123.js": "console.log('hi')",
+    })
+    r = _run(wheel)
+    assert r.returncode == 0, r.stderr
+    assert "contains PM Gantt UI assets" in r.stdout
+
+
+def test_fails_when_index_html_missing(tmp_path: Path) -> None:
+    wheel = tmp_path / "broken.whl"
+    _make_wheel(wheel, {
+        "specy_road/__init__.py": "",
+        "specy_road/pm_gantt_static/assets/index-abc123.js": "x",
+    })
+    r = _run(wheel)
+    assert r.returncode == 1
+    assert "specy_road/pm_gantt_static/index.html" in r.stderr
+
+
+def test_fails_when_no_js_chunk(tmp_path: Path) -> None:
+    wheel = tmp_path / "broken2.whl"
+    _make_wheel(wheel, {
+        "specy_road/__init__.py": "",
+        "specy_road/pm_gantt_static/index.html": "<!doctype html>",
+    })
+    r = _run(wheel)
+    assert r.returncode == 1
+    assert "specy_road/pm_gantt_static/assets/index-" in r.stderr
+
+
+def test_fails_when_wheel_missing(tmp_path: Path) -> None:
+    r = _run(tmp_path / "absent.whl")
+    assert r.returncode == 1
+    assert "wheel not found" in r.stderr


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds the full automated release pipeline that the post-F-001 README TODO
promised. Triggered by tags created by the existing
`main-release-tag-gate.yml` workflow (which now also accepts the
`v` prefix and PEP 440 prerelease suffixes). Routes finals to PyPI and
prereleases to TestPyPI via **OIDC trusted publishing** — no API tokens
in repo secrets.

Also lands the contributor-governance pieces from the prior conversation:
right of refusal, issues-first policy, malicious-code reporting policy,
enforced branch-naming convention.

## Workflow architecture

```
Human:   open PR  dev → main  with title 'release: vX.Y.Z'
Gate:    main-release-tag-gate.yml validates the marker; on merge,
         auto-creates the vX.Y.Z (or vX.Y.Z-rc1) tag at the merge commit.
Publish: release-publish.yml fires on the tag push:
           1. reuses validate.yml (now exposes workflow_call) as a prereq
           2. builds sdist + wheel (npm build the SPA first)
           3. asserts pyproject.version matches the tag (PEP 440 normalized)
           4. asserts wheel contains pm_gantt_static/index.html + index-*.js
           5. smoke-installs in a fresh venv, runs --help / validate / export
           6. publishes via OIDC trusted publishing
                - prereleases (vX.Y.Z-suffix) → TestPyPI (env: testpypi)
                - finals     (vX.Y.Z)         → PyPI    (env: pypi)
              with sigstore PEP 740 attestations enabled
           7. creates a GitHub Release with the matching ## [vX.Y.Z]
              section of CHANGELOG.md as the body
           8. on first PyPI publish, opens a draft chore/ PR that
              strips the README pre-release notice + TODO and swaps
              the install block to 'pip install specy-road'
```

## Files added

| Path | Role |
|------|------|
| `.github/workflows/release-publish.yml` | The publish pipeline |
| `.github/workflows/pr-conventions.yml` | Branch-naming + issues-first enforcement |
| `CHANGELOG.md` | Keep-a-changelog skeleton; release-publish extracts sections |
| `scripts/check_release_version.py` | Asserts pyproject.version matches tag (PEP 440 normalized) |
| `scripts/verify_wheel_contents.py` | Asserts wheel contains the bundled SPA |
| `scripts/post_release_readme_cleanup.py` | Idempotent README cleanup, run by the follow-up PR job |
| `tests/test_check_release_version.py` | 6 tests |
| `tests/test_verify_wheel_contents.py` | 4 tests |
| `tests/test_post_release_readme_cleanup.py` | 3 tests including a smoke run against the real README |

## Files changed

| Path | Change |
|------|--------|
| `.github/workflows/main-release-tag-gate.yml` | Accepts `v`-prefixed tags AND PEP 440 prerelease suffixes (`vX.Y.Z-rc1`, `vX.Y.Z-beta1`). Auto-creates `v`-prefixed tags. Notice output names the publish target. |
| `.github/workflows/validate.yml` | Adds `workflow_call` trigger so `release-publish.yml` can re-run the full validation pipeline on the tagged commit. |
| `docs/contributor-guide.md` | Project stewardship section (right of refusal + issues-first + malicious-code policy with explicit reporting list); branch-naming convention with the enforced regex; v-prefixed tags + prereleases; full automated-release process documented; one-time trust & environment setup checklist. |

## PR-conventions enforcement (`pr-conventions.yml`)

- **Branch name** must match `^(feature|fix|chore)/[a-z0-9]+(-[a-z0-9]+)*$`.
  Exempt: `cursor/*`, `dependabot/*`, `ci/*`.
- **PR body** must reference an issue (`Closes #N`, `Fixes #N`, `Refs #N`)
  unless the branch is `chore/*` or the PR has the `no-issue-required`
  label.

## OIDC trust binding

The PyPI Trusted Publisher OIDC trust is bound to **this exact workflow
file** (`release-publish.yml`) and the **`pypi`** / **`testpypi`** GitHub
environments. Renaming the file or environments would break publishing
until the trust is updated on `pypi.org` and `test.pypi.org` — the
contributor guide calls this out explicitly.

## Verification

- `pytest -q` → **390 passed** (376 prior + 14 new for the three release scripts).
- `yaml.safe_load` ok on all four workflow files.
- `scripts/post_release_readme_cleanup.py` smoke-tested against the
  current `README.md`: removes the pre-release notice block, the
  `TODO(post-release)` comment, and swaps the install-from-source block
  for `pip install specy-road`. Idempotent on re-run.
- `scripts/check_release_version.py` PEP 440 normalization tested for
  the `v0.1.0-rc1 ↔ 0.1.0rc1` case.
- `scripts/verify_wheel_contents.py` tested with synthetic wheels
  (passes when the SPA assets are present, fails clearly when they are
  not).

## Manual smoke (no publish)

`release-publish.yml` accepts a `workflow_dispatch` trigger with
`dry_run: true`. This builds the package and runs every verification
step but does NOT publish or create a release. Useful when refactoring
the workflow itself.

## How to cut the first release after this lands

1. Merge this PR to `dev`.
2. On `dev`: bump `pyproject.toml` `project.version` to `0.1.0rc1`,
   fill in `## [v0.1.0-rc1]` in `CHANGELOG.md`.
3. Open a release PR `dev → main` with title `release: v0.1.0-rc1`.
4. Merge it → tag `v0.1.0-rc1` is auto-created → `release-publish.yml`
   publishes to TestPyPI.
5. After confirming the TestPyPI install works, repeat with version
   `0.1.0` for the real PyPI publish; the follow-up README cleanup PR
   will be opened automatically.

## What this does NOT change

- No publication of any package — this PR is the wiring; the actual
  v0.1.0-rc1 release happens in a separate PR.
- No changes to `dev` or `main` directly outside this branch.
- No effect on roadmap commands or the `specy-road` CLI behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8cc693e-840e-4070-ab62-05d8fa0b9444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8cc693e-840e-4070-ab62-05d8fa0b9444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Automate tag-driven Python package releases and formalize contributor and PR governance.

New Features:
- Introduce a tag-triggered release workflow that builds, verifies, and publishes distributions to PyPI or TestPyPI via OIDC trusted publishing, and creates GitHub Releases from CHANGELOG entries.
- Add scripts to enforce that release tags match the pyproject version and that built wheels contain the bundled PM Gantt UI assets, plus a post-release README cleanup helper.
- Add a keep-a-changelog style CHANGELOG file to drive GitHub Release notes.

Enhancements:
- Expand the main-branch release gate to validate v-prefixed semantic version markers including prereleases, and to auto-create corresponding tags on merge.
- Make the existing validation workflow reusable so it can be re-run as a prerequisite in the release pipeline.

CI:
- Add a PR conventions workflow that enforces branch-naming rules and requires issue references in PR descriptions with limited exemptions.
- Add a release-publish workflow that coordinates validation, build, verification, publish, GitHub Release creation, and post-release README cleanup PR creation.

Documentation:
- Update the contributor guide with project stewardship expectations, an issues-first policy, a malicious code reporting policy, enforced branch-naming conventions, and detailed documentation of the automated tagging and release process including OIDC trust setup and manual dry-run options.

Tests:
- Add unit tests for the release helper scripts, including pyproject version/tag matching, wheel content verification, and README post-release cleanup idempotence.