### PR TITLE
fix(docs): replace dead CLAUDE.md link in toolkit-development.md

### DIFF
--- a/docs/toolkit-development.md
+++ b/docs/toolkit-development.md
@@ -41,7 +41,7 @@ With no path, the CLI uses the git worktree root—in **this** repo that would s
 
 **Application repositories** set `integration_branch` and `remote` in `roadmap/git-workflow.yaml` after `specy-road init project`; the CLI and PM Gantt read that file unless overridden by flags or environment variables (see [git-workflow.md](git-workflow.md)). Examples elsewhere that mention `main` or `dev` are illustrative—not a default for your repo.
 
-**This toolkit repository** uses its own policy for package work: topic branches merge to **`dev`**, and **`main`** is release-facing via promotion PRs—see [CLAUDE.md](../CLAUDE.md#repository-git-workflow-policy-current). That is **not** the workflow contract for other repos using specy-road; those stay configurable via `roadmap/git-workflow.yaml`.
+**This toolkit repository** uses its own policy for package work: topic branches merge to **`dev`**, and **`main`** is release-facing via promotion PRs auto-tagged by [`main-release-tag-gate.yml`](../.github/workflows/main-release-tag-gate.yml) and published by [`release-publish.yml`](../.github/workflows/release-publish.yml). The full branching, tagging, PR-conventions, and release process lives in [contributor-guide.md](contributor-guide.md#branching-tagging-and-release-process). That is **not** the workflow contract for other repos using specy-road; those stay configurable via `roadmap/git-workflow.yaml`.
 
 ## See also
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`docs/toolkit-development.md` contained a link to `../CLAUDE.md#repository-git-workflow-policy-current`,
but `CLAUDE.md` is intentionally `.gitignored` as a local-only agent-config
file (per the standard "AI / agents (local-only)" block in both the toolkit
and consumer-template `.gitignore`). Committed docs cannot rely on a
local-only file existing.

Replaces the broken anchor with a cross-link to the authoritative
branching/tagging/release section of `docs/contributor-guide.md`, and names
the two workflow files that implement the policy
(`main-release-tag-gate.yml` and `release-publish.yml`).

## Verification

- Dead-link sweep: before = 4 broken local links (including this one);
  after = 3 (all pre-existing template-y issues out of scope: a `vision.md`
  reference and two paths inside the `specyrd` template tree).
- Anchor target verified — `## Branching, tagging, and release process`
  exists at line 70 of `docs/contributor-guide.md`.
- `pytest -q` still 390 passing.
- `specy-road file-limits` OK.

## CI hint

This is a maintainer-internal `fix/` PR with no associated user issue.
Apply the `no-issue-required` label (created previously for the same
reason on PR #23) to clear the `pr-conventions / issue-link` check.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8cc693e-840e-4070-ab62-05d8fa0b9444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8cc693e-840e-4070-ab62-05d8fa0b9444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Documentation:
- Replace the dead link to a local-only CLAUDE.md file with references to the contributor guide and the GitHub workflow files that define the toolkit repository's branching and release process.