### PR TITLE
chore(deps): batch Dependabot bumps (Apr 2026)

### DIFF
--- a/.github/workflows/main-release-tag-gate.yml
+++ b/.github/workflows/main-release-tag-gate.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate release marker on PR to main
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TITLE_RE: ${{ env.RELEASE_TITLE_RE }}
           LABEL_RE: ${{ env.RELEASE_LABEL_RE }}
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Resolve release version from merged PR and create tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           TITLE_RE: ${{ env.RELEASE_TITLE_RE }}
           LABEL_RE: ${{ env.RELEASE_LABEL_RE }}

--- a/.github/workflows/pr-conventions.yml
+++ b/.github/workflows/pr-conventions.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate branch name
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const branch = context.payload.pull_request?.head?.ref || "";
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Require issue reference in PR body (with chore exemption)
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -162,7 +162,7 @@ jobs:
       name: testpypi
       url: https://test.pypi.org/p/specy-road
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -183,7 +183,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/specy-road
     steps:
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v6
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
@@ -233,7 +233,7 @@ jobs:
             echo '__NOTES_EOF__'
           } >> "${GITHUB_OUTPUT}"
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.resolve.outputs.tag }}
           name: ${{ needs.resolve.outputs.tag }}
@@ -262,7 +262,7 @@ jobs:
           set -euo pipefail
           python scripts/post_release_readme_cleanup.py "${{ needs.resolve.outputs.version }}"
       - name: Open follow-up PR if README changed
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/readme-post-release-${{ needs.resolve.outputs.version }}
           base: dev

--- a/gui/pm-gantt/package-lock.json
+++ b/gui/pm-gantt/package-lock.json
@@ -29,10 +29,10 @@
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
-        "eslint": "^10.2.0",
+        "eslint": "^10.2.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.5.0",
-        "typescript": "~6.0.2",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.8",
         "vitest": "^4.1.4"
@@ -603,9 +603,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -623,9 +620,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -643,9 +637,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -663,9 +654,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -683,9 +671,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,9 +688,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2119,18 +2101,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.0.tgz",
-      "integrity": "sha512-+L0vBFYGIpSNIt/KWTpFonPrqYvgKw1eUI5Vn7mEogrQcWtWYtNQ7dNqC+px/J0idT3BAkiWrhfS7k+Tum8TUA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
+      "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
-        "@eslint/config-array": "^0.23.4",
-        "@eslint/config-helpers": "^0.5.4",
-        "@eslint/core": "^1.2.0",
-        "@eslint/plugin-kit": "^0.7.0",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.5.5",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2963,9 +2945,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2987,9 +2966,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3011,9 +2987,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3035,9 +3008,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4858,9 +4828,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/gui/pm-gantt/package.json
+++ b/gui/pm-gantt/package.json
@@ -32,10 +32,10 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "eslint": "^10.2.0",
+    "eslint": "^10.2.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.5.0",
-    "typescript": "~6.0.2",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.8",
     "vitest": "^4.1.4"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -25,7 +25,7 @@ certifi==2026.2.25
     #   requests
 charset-normalizer==3.4.7
     # via requests
-fastapi==0.135.3
+fastapi==0.136.0
     # via specy-road
 h11==0.16.0
     # via httpcore


### PR DESCRIPTION
## Summary

Consolidates the open Dependabot PRs that were opened against **`main`** after the rc1 merge (**#29–#35**) onto a single **`chore/`** branch targeting **`dev`**, where CI and review match day-to-day toolkit work.

## Changes (same versions as the bot PRs)

| Area | Bump |
|------|------|
| GitHub Actions | `actions/download-artifact` v6 → v8; `actions/github-script` v7 → v9; `softprops/action-gh-release` v2 → v3; `peter-evans/create-pull-request` v7 → v8 |
| CI Python | `fastapi` 0.135.3 → 0.136.0 in `requirements-ci.txt` |
| PM Gantt | `eslint` ^10.2.0 → ^10.2.1; `typescript` ~6.0.2 → ~6.0.3 (`package.json` / lockfile) |

## Verification

- `cd gui/pm-gantt && npm ci && npm run lint && npm test && npm run build`
- `pytest` (same environment caveats as usual for tests that shell out to `git push`)

## After merge

Close **#29–#35** (or let Dependabot auto-close if GitHub links them).


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Update GitHub Actions and key dependencies across CI and the PM Gantt GUI.

Enhancements:
- Bump GitHub Actions used in release workflows, tag gating, and PR convention checks to their latest major versions.
- Upgrade eslint and TypeScript dependencies for the PM Gantt GUI project.
- Refresh CI-only Python dependency versions in requirements-ci.txt.

Build:
- Align CI and workflow tooling versions with current upstream releases to keep automation up to date.