### PR TITLE
release: v0.1.0-rc3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,30 @@ body. Keep section bodies focused; link to PRs for detail.
 
 ### Removed
 
+## [v0.1.0-rc3] - 2026-04-18
+
+Third prerelease (TestPyPI). CLI polish and roadmap dependency commands.
+
+### Added
+
+- CLI: `list-dependencies`, `set-dependencies` (`--clear` / `--deps`),
+  `add-dependency`, and `remove-dependency`, using the same
+  `edit_node_set_pairs` / validation path as the PM GUI
+  `PATCH /api/nodes/{id}` dependency updates.
+
+### Fixed
+
+- Top-level `specy-road` no longer prints a `CalledProcessError` traceback
+  when a pass-through bundled script exits non-zero (for example
+  `archive-node` for an unknown id); the child script’s stderr message
+  and exit code remain the contract.
+
+### Changed
+
+- Tests: `script_subprocess_env` prepends the repository root on
+  `PYTHONPATH` so subprocess invocations of bundled scripts resolve
+  `import specy_road` the same way the packaged CLI wrapper does.
+
 ## [v0.1.0-rc2] - 2026-04-18
 
 Second prerelease (TestPyPI). Unifies `dev` with `main` for promotion PRs,
@@ -186,6 +210,7 @@ the package wheel is correct.
   only cares that `integration_branch` is declared; the rest is the
   user's git hygiene. (F-005)
 
-[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.0-rc2...HEAD
+[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.0-rc3...HEAD
+[v0.1.0-rc3]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc3
 [v0.1.0-rc2]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc2
 [v0.1.0-rc1]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc1

--- a/docs/pm-workflow.md
+++ b/docs/pm-workflow.md
@@ -242,6 +242,11 @@ Use the terminal in the **repo root**. The main program is `**specy-road`** foll
 | `specy-road edit-node M0.1.1 --set status=Blocked` | Change allowed fields without hand-editing the chunk file. Validation runs after the save.                                                  |
 | `specy-road add-node`                              | Add a new item; run `specy-road add-node -h` for options.                                                                                   |
 | `specy-road archive-node M0.1.1 --hard-remove`    | Remove the node from the roadmap JSON after team agreement (the old “soft cancel” status was removed from the schema).                      |
+| `specy-road list-dependencies M0.1.1`            | Print this node’s **explicit** `dependencies` as **node_key** values (with id/title); same field the PM GUI edits.                         |
+| `specy-road set-dependencies M0.1.1 --clear`      | Clear explicit dependencies on that node (runs validate after save).                                                                       |
+| `specy-road set-dependencies M0.1.1 --deps "…"`   | Replace explicit dependencies with a space/comma-separated list of **node_key** strings (same rules as `edit-node … dependencies=…`).       |
+| `specy-road add-dependency M0.1.1 <NODE_KEY>`     | Append one **node_key** dependency if it is not already listed.                                                                            |
+| `specy-road remove-dependency M0.1.1 <NODE_KEY>`  | Remove one **node_key** dependency if present.                                                                                               |
 | `specy-road brief M0.1.1`                          | Show the same “brief” a developer sees for that item (good for spot checks).                                                                |
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "specy-road"
 # Canonical version: `specy_road.__version__` reads this via importlib.metadata.
-version = "0.1.0rc2"
+version = "0.1.0rc3"
 description = "Roadmap-first coordination kit for humans and AI agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/specy_road/__init__.py
+++ b/specy_road/__init__.py
@@ -6,4 +6,4 @@ try:
     __version__ = version("specy-road")
 except PackageNotFoundError:
     # Editable/dev without metadata (e.g. partial PYTHONPATH)
-    __version__ = "0.1.0rc2"
+    __version__ = "0.1.0rc3"

--- a/specy_road/bundled_scripts/roadmap_crud.py
+++ b/specy_road/bundled_scripts/roadmap_crud.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PM-oriented roadmap CRUD: list/show/add/edit/archive nodes in JSON chunk files."""
+"""PM-oriented roadmap CRUD: list/show/add/edit/archive nodes; dependency subcommands."""
 
 from __future__ import annotations
 

--- a/specy_road/bundled_scripts/roadmap_crud_argparse.py
+++ b/specy_road/bundled_scripts/roadmap_crud_argparse.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from roadmap_crud_dependency_ops import (
+    cmd_add_dependency,
+    cmd_list_dependencies,
+    cmd_remove_dependency,
+    cmd_set_dependencies,
+)
 from roadmap_crud_ops import cmd_add, cmd_archive, cmd_edit, cmd_list, cmd_show
 
 
@@ -76,6 +82,56 @@ def _p_edit(sub: argparse._SubParsersAction) -> None:
     sp.set_defaults(func=cmd_edit)
 
 
+def _p_list_dependencies(sub: argparse._SubParsersAction) -> None:
+    sp = sub.add_parser(
+        "list-dependencies",
+        help="Print explicit dependency node_keys for a node (tab: node_key, id, title)",
+    )
+    sp.add_argument("node_id", metavar="NODE_ID")
+    sp.set_defaults(func=cmd_list_dependencies)
+
+
+def _p_set_dependencies(sub: argparse._SubParsersAction) -> None:
+    sp = sub.add_parser(
+        "set-dependencies",
+        help="Replace explicit dependencies (node_keys); same validation as PM GUI patch",
+    )
+    sp.add_argument("node_id", metavar="NODE_ID")
+    mx = sp.add_mutually_exclusive_group(required=True)
+    mx.add_argument(
+        "--clear",
+        action="store_true",
+        help="Remove all explicit dependencies on this node",
+    )
+    mx.add_argument(
+        "--deps",
+        dest="deps_raw",
+        metavar="KEYS",
+        help="Space/comma/semicolon-separated dependency node_keys (same as edit-node dependencies=…)",
+    )
+    sp.set_defaults(func=cmd_set_dependencies)
+
+
+def _p_add_dependency(sub: argparse._SubParsersAction) -> None:
+    sp = sub.add_parser(
+        "add-dependency",
+        help="Append one dependency node_key if missing (uses edit_node_set_pairs / validate)",
+    )
+    sp.add_argument("node_id", metavar="NODE_ID")
+    sp.add_argument("dep_node_key", metavar="DEP_NODE_KEY")
+    sp.set_defaults(func=cmd_add_dependency)
+
+
+def _p_remove_dependency(sub: argparse._SubParsersAction) -> None:
+    sp = sub.add_parser(
+        "remove-dependency",
+        help="Remove one dependency node_key if present",
+    )
+    sp.add_argument("node_id", metavar="NODE_ID")
+    sp.add_argument("dep_node_key", metavar="DEP_NODE_KEY")
+    sp.set_defaults(func=cmd_remove_dependency)
+
+
 def _p_archive(sub: argparse._SubParsersAction) -> None:
     sp = sub.add_parser(
         "archive-node",
@@ -105,5 +161,9 @@ def build_parser() -> argparse.ArgumentParser:
     _p_show(sub)
     _p_add(sub)
     _p_edit(sub)
+    _p_list_dependencies(sub)
+    _p_set_dependencies(sub)
+    _p_add_dependency(sub)
+    _p_remove_dependency(sub)
     _p_archive(sub)
     return p

--- a/specy_road/bundled_scripts/roadmap_crud_dependency_ops.py
+++ b/specy_road/bundled_scripts/roadmap_crud_dependency_ops.py
@@ -1,0 +1,114 @@
+"""Dependency-focused roadmap CRUD subcommands (CLI; same backend as PM GUI patch)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from roadmap_chunk_utils import find_chunk_path
+from roadmap_crud_ops import edit_node_set_pairs, repo_root, unknown_node_msg
+from roadmap_load import load_roadmap
+
+
+def merged_node_by_id(root: Path, node_id: str) -> dict | None:
+    for n in load_roadmap(root)["nodes"]:
+        if isinstance(n, dict) and n.get("id") == node_id:
+            return n
+    return None
+
+
+def _dependencies_patch_value(keys: list[str]) -> str:
+    """String for ``dependencies=`` patches (same ordering as the PM GUI)."""
+    return " ".join(sorted(keys))
+
+
+def cmd_list_dependencies(args: object) -> None:
+    root = repo_root(args)
+    nid = args.node_id
+    rec = merged_node_by_id(root, nid)
+    if not rec:
+        print(f"error: {unknown_node_msg(nid)}", file=sys.stderr)
+        raise SystemExit(1)
+    deps = [str(x) for x in (rec.get("dependencies") or []) if x]
+    if not deps:
+        print("(none)")
+        return
+    nodes = load_roadmap(root)["nodes"]
+    by_key: dict[str, dict] = {}
+    for n in nodes:
+        if isinstance(n, dict):
+            k = n.get("node_key")
+            if isinstance(k, str) and k:
+                by_key[k] = n
+    for dk in deps:
+        row = by_key.get(dk)
+        if row:
+            oid = str(row.get("id", ""))
+            title = str(row.get("title", ""))[:72]
+            print(f"{dk}\t{oid}\t{title}")
+        else:
+            print(f"{dk}\t?\t(missing node_key in roadmap)")
+
+
+def cmd_set_dependencies(args: object) -> None:
+    root = repo_root(args)
+    nid = args.node_id
+    raw = "" if args.clear else (args.deps_raw or "")
+    try:
+        edit_node_set_pairs(root, nid, [("dependencies", raw)])
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
+    chunk = find_chunk_path(root, nid)
+    assert chunk is not None
+    print(f"[ok] dependencies updated for {nid} in {chunk.relative_to(root)}")
+
+
+def cmd_add_dependency(args: object) -> None:
+    root = repo_root(args)
+    nid = args.node_id
+    dep_key = args.dep_node_key
+    rec = merged_node_by_id(root, nid)
+    if not rec:
+        print(f"error: {unknown_node_msg(nid)}", file=sys.stderr)
+        raise SystemExit(1)
+    cur = [str(x) for x in (rec.get("dependencies") or []) if x]
+    if dep_key in cur:
+        print(f"[ok] {nid} already lists dependency {dep_key!r}")
+        return
+    cur.append(dep_key)
+    try:
+        edit_node_set_pairs(
+            root, nid, [("dependencies", _dependencies_patch_value(cur))]
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
+    chunk = find_chunk_path(root, nid)
+    assert chunk is not None
+    print(f"[ok] added {dep_key!r} to {nid} in {chunk.relative_to(root)}")
+
+
+def cmd_remove_dependency(args: object) -> None:
+    root = repo_root(args)
+    nid = args.node_id
+    dep_key = args.dep_node_key
+    rec = merged_node_by_id(root, nid)
+    if not rec:
+        print(f"error: {unknown_node_msg(nid)}", file=sys.stderr)
+        raise SystemExit(1)
+    cur = [str(x) for x in (rec.get("dependencies") or []) if x]
+    if dep_key not in cur:
+        print(f"[ok] {nid} did not list dependency {dep_key!r}")
+        return
+    new_keys = [x for x in cur if x != dep_key]
+    try:
+        edit_node_set_pairs(
+            root, nid, [("dependencies", _dependencies_patch_value(new_keys))]
+        )
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1) from None
+    chunk = find_chunk_path(root, nid)
+    assert chunk is not None
+    print(f"[ok] removed {dep_key!r} from {nid} in {chunk.relative_to(root)}")

--- a/specy_road/bundled_scripts/roadmap_crud_dependency_ops.py
+++ b/specy_road/bundled_scripts/roadmap_crud_dependency_ops.py
@@ -1,4 +1,4 @@
-"""Dependency-focused roadmap CRUD subcommands (CLI; same backend as PM GUI patch)."""
+"""Roadmap dependency CRUD for the CLI (same edit path as the PM GUI patch)."""
 
 from __future__ import annotations
 

--- a/specy_road/bundled_scripts/roadmap_crud_ops.py
+++ b/specy_road/bundled_scripts/roadmap_crud_ops.py
@@ -32,6 +32,11 @@ def repo_root(ns: object) -> Path:
     return Path(r).resolve() if r else default_user_repo_root()
 
 
+def unknown_node_msg(node_id: str) -> str:
+    """User-facing text when a node id is not present in the merged roadmap."""
+    return f"no roadmap node with id {node_id!r} (not found in any chunk)"
+
+
 def run_validate_raise(root: Path) -> None:
     """Run roadmap + registry validation; raise ``ValueError`` with stderr text on failure."""
     err = io.StringIO()
@@ -80,7 +85,7 @@ def cmd_show(args: object) -> None:
     nid = args.node_id
     chunk = find_chunk_path(root, nid)
     if not chunk:
-        print(f"error: no chunk contains node {nid!r}", file=sys.stderr)
+        print(f"error: {unknown_node_msg(nid)}", file=sys.stderr)
         raise SystemExit(1)
     print(f"# chunk: {chunk.relative_to(root)}\n")
     if chunk.suffix.lower() == ".json":
@@ -221,7 +226,7 @@ def edit_node_set_pairs(root: Path, node_id: str, pairs: list[tuple[str, str]]) 
     """
     chunk = find_chunk_path(root, node_id)
     if not chunk:
-        raise ValueError(f"no chunk contains node {node_id!r}")
+        raise ValueError(unknown_node_msg(node_id))
     if chunk.suffix.lower() == ".json":
         nodes = load_json_chunk(chunk)
         idx = node_index_in_chunk(nodes, node_id)
@@ -272,7 +277,7 @@ def cmd_edit(args: object) -> None:
         edit_node_set_pairs(root, nid, pairs)
     except ValueError as e:
         print(f"error: {e}", file=sys.stderr)
-        raise SystemExit(1) from e
+        raise SystemExit(1) from None
     chunk = find_chunk_path(root, nid)
     assert chunk is not None
     print(f"[ok] updated {nid} in {chunk.relative_to(root)}")
@@ -297,7 +302,7 @@ def delete_roadmap_node_hard(root: Path, node_id: str) -> None:
     """Remove a node from its JSON chunk. Raises ``ValueError`` if not found or not removable."""
     chunk = find_chunk_path(root, node_id)
     if not chunk:
-        raise ValueError(f"no chunk contains node {node_id!r}")
+        raise ValueError(unknown_node_msg(node_id))
     if chunk.suffix.lower() != ".json":
         raise ValueError(f"unsupported chunk type {chunk.suffix}")
     nodes = load_json_chunk(chunk)
@@ -322,7 +327,7 @@ def cmd_archive(args: object) -> None:
             delete_roadmap_node_hard(root, nid)
         except ValueError as e:
             print(f"error: {e}", file=sys.stderr)
-            raise SystemExit(1) from e
+            raise SystemExit(1) from None
         print(f"[ok] removed {nid}")
         return
     print(

--- a/specy_road/cli.py
+++ b/specy_road/cli.py
@@ -138,7 +138,11 @@ def _run(script: str, args: list[str]) -> None:
     prefix = f"{repo_or_site}{sep}{d}"
     env["PYTHONPATH"] = prefix + (sep + prev if prev else "")
     cmd = [sys.executable, str(script_path), *args]
-    subprocess.check_call(cmd, env=env)
+    proc = subprocess.run(cmd, env=env)
+    if proc.returncode != 0:
+        # Avoid chaining from CalledProcessError: bundled scripts already print
+        # stderr messages; surfacing subprocess.check_call adds a noisy traceback.
+        raise SystemExit(proc.returncode) from None
 
 
 def _cmd_scaffold_constitution(rest: list[str]) -> None:

--- a/specy_road/cli.py
+++ b/specy_road/cli.py
@@ -32,6 +32,10 @@ _USAGE_TEXT = (
     "  add-node ...         — see: python specy_road/bundled_scripts/roadmap_crud.py add-node -h\n"
     "  edit-node ...\n"
     "  archive-node ...\n"
+    "  list-dependencies <NODE_ID>\n"
+    "  set-dependencies <NODE_ID> (--clear | --deps \"KEY …\")\n"
+    "  add-dependency <NODE_ID> <DEP_NODE_KEY>\n"
+    "  remove-dependency <NODE_ID> <DEP_NODE_KEY>\n"
     "  review-node <NODE_ID> — advisory LLM review (requires pip install specy-road[review])\n"
     "  scaffold-planning <NODE_ID> — create planning/<id>_<slug>_<node_key>.md; set planning_dir\n"
     "    (optional: --planning-dir PATH --force; see specy_road/bundled_scripts/scaffold_planning.py -h)\n"
@@ -279,6 +283,10 @@ def main(argv: list[str] | None = None) -> None:
         "add-node",
         "edit-node",
         "archive-node",
+        "list-dependencies",
+        "set-dependencies",
+        "add-dependency",
+        "remove-dependency",
     ):
         _run("roadmap_crud.py", _args_repo_root_first([cmd, *rest]))
     elif cmd == "review-node":

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -15,5 +15,7 @@ def script_subprocess_env() -> dict[str, str]:
     env = os.environ.copy()
     sep = os.pathsep
     prev = env.get("PYTHONPATH", "")
-    env["PYTHONPATH"] = str(BUNDLED_SCRIPTS) + (sep + prev if prev else "")
+    # Repo root so `import specy_road` works; bundled_scripts for flat imports.
+    prefix = f"{REPO}{sep}{BUNDLED_SCRIPTS}"
+    env["PYTHONPATH"] = prefix + (sep + prev if prev else "")
     return env

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,6 +64,50 @@ def test_specy_road_list_nodes() -> None:
     assert "M0" in r.stdout
 
 
+def test_specy_road_archive_unknown_node_no_traceback(tmp_path: Path) -> None:
+    """Bundled script stderr is enough; top-level CLI must not chain CalledProcessError."""
+    import shutil
+
+    from tests.helpers import SCHEMAS
+
+    dest = tmp_path / "proj"
+    shutil.copytree(SCHEMAS, dest / "schemas")
+    shutil.copytree(REPO / "constraints", dest / "constraints")
+    (dest / "roadmap" / "phases").mkdir(parents=True)
+    (dest / "shared").mkdir(parents=True)
+    (dest / "shared" / "README.md").write_text("# Shared\n", encoding="utf-8")
+    (dest / "roadmap" / "registry.yaml").write_text(
+        "version: 1\nentries: []\n",
+        encoding="utf-8",
+    )
+    (dest / "roadmap" / "manifest.json").write_text(
+        '{"version": 1, "includes": ["phases/T.json"]}\n',
+        encoding="utf-8",
+    )
+    (dest / "roadmap" / "phases" / "T.json").write_text("[]\n", encoding="utf-8")
+
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "specy_road.cli",
+            "archive-node",
+            "M0.1.1",
+            "--hard-remove",
+            "--repo-root",
+            str(dest),
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 1
+    err = (r.stderr or "") + (r.stdout or "")
+    assert "Traceback" not in err
+    assert "CalledProcessError" not in err
+    assert "no roadmap node" in err
+
+
 def test_specy_road_show_node() -> None:
     r = subprocess.run(
         [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,25 @@ def test_specy_road_archive_unknown_node_no_traceback(tmp_path: Path) -> None:
     assert "no roadmap node" in err
 
 
+def test_specy_road_list_dependencies() -> None:
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "specy_road.cli",
+            "list-dependencies",
+            "M0.1",
+            "--repo-root",
+            str(DOGFOOD),
+        ],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert r.returncode == 0, r.stderr
+
+
 def test_specy_road_show_node() -> None:
     r = subprocess.run(
         [

--- a/tests/test_roadmap_crud.py
+++ b/tests/test_roadmap_crud.py
@@ -143,6 +143,21 @@ def test_append_node_validate(tmp_path: Path) -> None:
     assert v.returncode == 0, v.stderr
 
 
+def test_archive_node_unknown_id_message(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+    r = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "archive-node",
+        "M404.1",
+        "--hard-remove",
+    )
+    assert r.returncode == 1
+    assert "no roadmap node" in r.stderr
+    assert "M404.1" in r.stderr
+
+
 def test_hard_remove_blocked_by_dependency(tmp_path: Path) -> None:
     _fixture_repo(tmp_path)
     r = _run_crud(

--- a/tests/test_roadmap_crud_dependencies.py
+++ b/tests/test_roadmap_crud_dependencies.py
@@ -1,0 +1,132 @@
+"""CLI tests for roadmap dependency subcommands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.test_roadmap_crud import _fixture_repo, _run_crud
+
+
+def test_list_dependencies_cli(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+    nk991 = "10000000-0000-4000-8000-000000009902"
+    r = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M99.2",
+    )
+    assert r.returncode == 0, r.stderr
+    assert nk991 in r.stdout
+    assert "M99.1" in r.stdout
+
+
+def test_list_dependencies_empty_and_unknown(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+    r = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M99.1",
+    )
+    assert r.returncode == 0, r.stderr
+    assert "(none)" in r.stdout
+    r404 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M404",
+    )
+    assert r404.returncode == 1
+    assert "no roadmap node" in r404.stderr
+
+
+def test_add_remove_dependency_cli(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+    nk992 = "10000000-0000-4000-8000-000000009903"
+    r0 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "set-dependencies",
+        "M99.2",
+        "--clear",
+    )
+    assert r0.returncode == 0, r0.stderr
+    r = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "add-dependency",
+        "M99.1",
+        nk992,
+    )
+    assert r.returncode == 0, r.stderr
+    r2 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M99.1",
+    )
+    assert nk992 in r2.stdout
+    r3 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "remove-dependency",
+        "M99.1",
+        nk992,
+    )
+    assert r3.returncode == 0, r3.stderr
+    r4 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M99.1",
+    )
+    assert "(none)" in r4.stdout
+
+
+def test_set_dependencies_clear_and_restore(tmp_path: Path) -> None:
+    _fixture_repo(tmp_path)
+    nk991 = "10000000-0000-4000-8000-000000009902"
+    r = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "set-dependencies",
+        "M99.2",
+        "--clear",
+    )
+    assert r.returncode == 0, r.stderr
+    r2 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M99.2",
+    )
+    assert "(none)" in r2.stdout
+    r3 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "set-dependencies",
+        "M99.2",
+        "--deps",
+        nk991,
+    )
+    assert r.returncode == 0, r.stderr
+    r4 = _run_crud(
+        tmp_path,
+        "--repo-root",
+        str(tmp_path),
+        "list-dependencies",
+        "M99.2",
+    )
+    assert nk991 in r4.stdout


### PR DESCRIPTION
## Summary

Prerelease **v0.1.0-rc3** for Test PyPI.

### Included (since `main` / rc2)
- CLI: no traceback on bundled script failure (`subprocess.run` + clean `SystemExit`).
- Clearer unknown-node errors for archive/show/edit.
- Dependency subcommands: `list-dependencies`, `set-dependencies`, `add-dependency`, `remove-dependency` (same `edit_node_set_pairs` as PM GUI).
- Test `PYTHONPATH` alignment for bundled script subprocesses.

### After merge
- `main-release-tag-gate.yml` creates tag `v0.1.0-rc3` on the merge commit.
- `release-publish.yml` publishes to **Test PyPI** (prerelease) and opens a GitHub Release.

### Version
- `pyproject.toml` / `CHANGELOG.md` / `__init__` fallback: **0.1.0rc3** matches tag `v0.1.0-rc3` (verified with `scripts/check_release_version.py`).

Supersedes closed PR #38 (branch renamed to satisfy `chore/` naming for PR conventions).

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Prepare v0.1.0-rc3 prerelease with CLI roadmap dependency management, clearer unknown-node errors, and improved subprocess handling for bundled scripts.

New Features:
- Add CLI subcommands and bundled script support to list, set, add, and remove roadmap dependencies for a node, sharing validation with the PM GUI.

Bug Fixes:
- Prevent the top-level specy-road CLI from emitting noisy CalledProcessError tracebacks when bundled scripts fail, relying instead on their stderr and exit codes.
- Unify and clarify user-facing error messages when roadmap node IDs are unknown across show, edit, archive, and dependency operations.

Enhancements:
- Adjust subprocess PYTHONPATH handling so bundled script invocations resolve the specy_road package consistently with the packaged CLI wrapper.

Build:
- Bump project and fallback package version metadata to 0.1.0rc3 and update the changelog and release links for v0.1.0-rc3.

Documentation:
- Document the new dependency management CLI commands in the PM workflow guide, including examples of typical usage.

Tests:
- Add tests covering dependency CLI subcommands, bundled script failure behavior, and unknown-node messaging, and align helper subprocess environments with the runtime behavior.