### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,28 +11,119 @@ body. Keep section bodies focused; link to PRs for detail.
 
 ## [Unreleased]
 
+## [v0.1.0] - 2026-04-22
+
+First **stable release** of `specy-road`. Promotes the work landed
+across `v0.1.0-rc1` … `v0.1.0-rc4` plus the post-rc4 milestone-delivery
+lifecycle, version-resolution policy, PM-Gantt UX improvements, and a
+review-driven graceful-error-handling pass. Tagged `v0.1.0` on `main`;
+the `release-publish` workflow routes the wheel to **PyPI** via OIDC.
+
 ### Added
 
-- **Milestone delivery and PM lock:** roadmap nodes may carry
-  **`milestone_execution`** (written by `start-milestone-session`). While
-  `state` is `active` or `pending_mr`, the PM API blocks outline and field
-  edits under that subtree (**409**). **`specy-road reconcile-milestone-status`**
-  (dry-run by default; `--apply`, optional `--fallback-head-delivery`) closes
-  the milestone when the rollup branch is merged into integration
-  (`git merge-base`), syncing parent `status`. `finish-this-task` on the
-  milestone rollup path may promote `active` → `pending_mr` when all subtree
-  leaves are complete.
+- **Milestone delivery lifecycle (`milestone_execution`).** Roadmap
+  parents may now carry an executable milestone state written to the
+  chunk JSON: **`active`** (rollup branch open, subtree being worked),
+  **`pending_mr`** (every structural leaf is `Complete`, awaiting the
+  rollup MR), **`closed`** (rollup branch merged into integration,
+  parent `status` synced to `Complete`). `start-milestone-session`
+  writes the `active` block on the parent chunk so the lock is
+  team-visible the moment it is committed. `finish-this-task` on the
+  milestone rollup path auto-promotes `active → pending_mr` when the
+  last leaf completes.
+
+- **PM subtree lock.** While `milestone_execution.state` is `active`
+  or `pending_mr`, both the CLI (`edit-node`, `set-gate-status`) and
+  the PM Gantt API (`PATCH /api/nodes/{id}`, `DELETE`,
+  `POST /api/outline/{reorder,move}`, `POST /api/nodes/{id}/{indent,outdent}`)
+  refuse mutations under that subtree with a clear error / **409
+  Conflict** that points the user at `specy-road reconcile-milestone-status`.
+
+- **`specy-road reconcile-milestone-status`** CLI. Dry-run by default;
+  `--apply` writes; `--fallback-head-delivery` accepts HEAD as the
+  source of truth when remote-tracking refs cannot prove the rollup
+  merge (typically: local-only merges or detached integration-branch
+  flows). Each per-node application is isolated — one failing parent
+  prints a structured warning and the loop continues; under `--apply`
+  the script exits non-zero so orchestration can detect partial
+  failure.
+
+- **PM Gantt: Tiptap task lists** in the markdown editor with a new
+  toolbar button and nested-checkbox CSS for both the editor surface
+  and the rendered preview. Constitution modal markdown editors now
+  size to content (no more 0-height collapse).
 
 ### Changed
 
-- `specy_road.__version__`: when the package is loaded from a tree that
-  contains a sibling `pyproject.toml` declaring `name = "specy-road"`, the
-  version is taken from that file (so editable checkouts and `specyrd init`
-  stubs match `project.version` even if install metadata is stale). If
-  there is no such file (e.g. a wheel-only install), use
-  `importlib.metadata`. Otherwise `0.0.0+unknown`. Maintainer docs and Cursor
-  rules now call out keeping tags, `pyproject.toml`, and `CHANGELOG.md` in
+- **`specy_road.__version__`** resolution policy: when the package is
+  loaded from a tree that contains a sibling `pyproject.toml`
+  declaring `name = "specy-road"`, the version is taken from that
+  file — so editable checkouts and `specyrd init` stubs match
+  `project.version` even when install metadata is stale. If there is
+  no such file (e.g. a wheel-only install), use
+  `importlib.metadata.version("specy-road")`. Otherwise the sentinel
+  `0.0.0+unknown`. The lookup is hardened against a malformed
+  `pyproject.toml` (catches `OSError` **and**
+  `tomllib.TOMLDecodeError` / `ValueError`); `import specy_road`
+  cannot crash on a broken file. Maintainer docs and Cursor rules now
+  call out keeping tags, `pyproject.toml`, and `CHANGELOG.md` in
   lockstep.
+
+- **Natural numeric sort for roadmap display ids.** `M1.2 < M1.10`
+  (and any nested digit run) on every surface that orders roadmap
+  rows: the export `roadmap.md` index, the `list-nodes` CLI, the PM
+  Gantt outline, and the optimistic in-browser sort. Python and
+  TypeScript implementations share the same key shape so the wire
+  ordering matches the in-process ordering exactly.
+
+### Fixed
+
+- **`POST /api/outline/move` with an unknown `node_key`** is once
+  again **400** with `unknown node_key '…'`. The
+  milestone-lock-guard pre-lookup added during rc4 had regressed it
+  to **404**; the original 400 contract (and the test that asserts
+  it) is restored.
+
+- **PM API milestone-lock guard** survives a transiently-broken
+  roadmap. If `load_roadmap` fails (corrupt chunk, missing manifest,
+  unreadable file) inside the lock-check, the route returns **409**
+  with a "run `specy-road validate`" hint instead of leaking a bare
+  500. The PM UI's transparent retry contract is wired for 4xx; a
+  500 used to halt the retry loop.
+
+- **PM Gantt mutation-fingerprint guard** survives an unreadable
+  manifest. A corrupt `roadmap/manifest.json` now produces a
+  **409** with `{message, error, retryable: false}` from the
+  optimistic-concurrency dependency; previously it raised a
+  `JSONDecodeError` and surfaced as a 500.
+
+- **`start-milestone-session` re-entry guard.** Running the script a
+  second time on a parent already in `active`/`pending_mr` refuses
+  cleanly with the documented `reconcile-milestone-status` hint
+  instead of silently overwriting the in-flight rollup metadata.
+
+### Maintenance
+
+- File-limits compliance: refactored `register_node_mutations`
+  (90 → 13 lines; per-route handlers now live at module level) and
+  `reconcile_milestone_status.main` (98 → 30 lines; per-node planner
+  + emitter helpers extracted). No behavior change.
+
+- Test suite: 480 → **495 passing**. New coverage for
+  `__version__` resolution (×3), PM API milestone lock end-to-end
+  (×5), graceful failure modes in lock-guard / fingerprint-guard
+  (×4), per-node isolation in `reconcile-milestone-status` (×2),
+  `start-milestone-session` re-entry guard (×1). Hardened the
+  `_shared_catalog` cache-invalidation test against the
+  same-nanosecond rewrite flake observed on fast tmpfs.
+
+- Repo policy: `.cursor/rules/*.mdc` (7 rules) tracked in the
+  repository — entry/load order, roadmap+registry discipline,
+  do-next-available registry publish, change discipline, PM-Gantt
+  ESLint stack, release/version/tag sync, and git-workflow
+  management. `CLAUDE.md` is now tracked at the repo root; the
+  `.gitignore` carve-out keeps IDE/agent state ignored while the
+  policy remains version-controlled.
 
 ## [v0.1.0-rc4] - 2026-04-20
 
@@ -273,7 +364,8 @@ the package wheel is correct.
   only cares that `integration_branch` is declared; the rest is the
   user's git hygiene. (F-005)
 
-[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.0-rc4...HEAD
+[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0
 [v0.1.0-rc4]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc4
 [v0.1.0-rc3]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc3
 [v0.1.0-rc2]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0-rc2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "specy-road"
 # Canonical version: `specy_road.__version__` prefers this file when the
 # package lives under this repo; else importlib.metadata; else `0.0.0+unknown`.
-version = "0.1.0rc4"
+version = "0.1.0"
 description = "Roadmap-first coordination kit for humans and AI agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# `specy-road` v0.1.0 — first stable release to PyPI

This is the **first official release of `specy-road` to PyPI**. After
four prerelease candidates on TestPyPI (`v0.1.0-rc1` … `v0.1.0-rc4`)
the toolkit is stable enough to recommend a plain
`pip install specy-road`. The `Main Release Tag Gate` workflow
validates the `release: v0.1.0` marker on this PR title; on merge the
post-merge automation creates tag **`v0.1.0`** on the merged commit;
[`release-publish.yml`](../blob/main/.github/workflows/release-publish.yml)
then routes the wheel to **PyPI** via the OIDC trusted publisher
(`environment: pypi`).

## What this PR contains

A single commit (`70bbaac release: v0.1.0`) on top of the just-merged
`main`:

- `pyproject.toml`: `version = "0.1.0rc4"` → `"0.1.0"`
- `CHANGELOG.md`: `[Unreleased]` block folded into
  `## [v0.1.0] - 2026-04-22` with the post-rc4 milestone-delivery /
  version-policy / graceful-error-handling items expanded into the
  release notes that `release-publish.yml` extracts as the GitHub
  Release body

`python scripts/check_release_version.py v0.1.0` passes locally on
this commit.

## What v0.1.0 ships

`v0.1.0` is the rollup of every prerelease (`rc1` → `rc4`) plus the
post-rc4 `feature/improvements` work that landed on `main` through
PRs #47 and #49. Full per-release breakdown lives in
[`CHANGELOG.md`](../blob/main/CHANGELOG.md); `release-publish.yml`
extracts the `## [v0.1.0]` block as the GitHub Release body.

### What you can do as of v0.1.0

- **`pip install specy-road`** then **`specy-road init project`** to
  scaffold a roadmap-first repository.
- Validate / export / file-limits / brief / list-nodes / add-node /
  edit-node / set-gate-status / dependency CRUD all on the CLI.
- Drive the dev pickup loop: `do-next-available-task` → implement on
  `feature/rm-<codename>` → `mark-implementation-reviewed` →
  `finish-this-task` (`pr` / `merge` / `auto`).
- Run the milestone-rollup flow with the new `milestone_execution`
  lifecycle: `start-milestone-session`,
  `do-next-available-task --milestone-subtree`, `open-milestone-pr`,
  `reconcile-milestone-status`. PM API blocks edits under any active
  or pending-MR milestone subtree with **409** + a
  `reconcile-milestone-status` hint.
- Run the PM Gantt UI (`specy-road gui`) with Tiptap task lists in
  the markdown editor, natural numeric sort for display ids,
  optimistic-concurrency mutation guard.
- LLM-assisted reviews (`specy-road review-node`) with the
  dependency-aware brief routing built into the system prompts.
- Adopt the agent-glue layer (`specyrd init`).

### Highlights vs `v0.1.0-rc4`

- **Milestone delivery lifecycle** (`milestone_execution`: `active` /
  `pending_mr` / `closed`) + PM subtree lock + new
  `reconcile-milestone-status` CLI.
- **`__version__` resolution policy**: prefer sibling
  `pyproject.toml`; hardened against malformed TOML so
  `import specy_road` cannot crash.
- **PM Gantt UX**: Tiptap task lists; constitution modal sizing;
  natural numeric sort for display ids on Python and TS sides.
- **Graceful error handling**: every previously-leaked 5xx route on
  the milestone-lock / mutation-fingerprint paths is now a 4xx with
  a human-readable hint. `reconcile-milestone-status --apply`
  isolates per-node failures and exits non-zero on partial failure.
  `start-milestone-session` re-entry refuses cleanly.
  `POST /api/outline/move` with unknown `node_key` is **400**
  (regressed to 404 in rc4).
- **File-limits compliance**: `register_node_mutations` and
  `reconcile_milestone_status.main` refactored under the
  per-function 80-line cap.
- **Test suite**: 480 → 495 passing.

## Pre-release verification

| Gate | Result |
|---|---|
| `python scripts/check_release_version.py v0.1.0` | `ok: pyproject version '0.1.0' matches tag 'v0.1.0'` |
| `specy-road validate / export --check / file-limits` | OK |
| `pytest -q` | **495 passed** in 124s |
| `gui/pm-gantt: npm ci && lint && test && build` | 0 errors / 51 pre-existing warnings; 113/113 tests; build OK; bundle reproducible byte-for-byte |
| `pip-audit` | No known vulnerabilities |
| `npm audit --omit=dev` (pm-gantt) | 0 vulnerabilities |
| End-to-end milestone delivery walk (`playground-dev/run_e2e.sh`) | 14/14 PASS |

## After merge

1. `Main Release Tag Gate` validates `release: v0.1.0`.
2. Tag-gate post-merge step creates `v0.1.0` on the merged `main`
   commit.
3. The agent will re-push the tag externally (GITHUB_TOKEN-created
   tags do not trigger downstream workflows per GitHub policy).
4. `release-publish.yml` builds the wheel and publishes to PyPI via
   OIDC (`environment: pypi`).
5. Smoke install: `pip install specy-road==0.1.0 && specy-road --help`.
6. Back-merge `main → dev` (chore commit).
7. Cleanup merged branches and session aliases.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-abd1e302-bc26-43ac-89aa-71ec78226ac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abd1e302-bc26-43ac-89aa-71ec78226ac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Cut the first stable v0.1.0 release and document the milestone lifecycle, versioning policy, UX improvements, and robustness fixes since rc4.

New Features:
- Introduce a milestone execution lifecycle with active, pending_mr, and closed states and corresponding CLI support via specy-road reconcile-milestone-status.
- Add PM subtree locking that blocks edits under active or pending_mr milestones across both CLI and PM Gantt API surfaces.
- Enable Tiptap task lists and improved markdown editing in the PM Gantt UI, including better constitution modal sizing.

Bug Fixes:
- Restore POST /api/outline/move with an unknown node_key to returning HTTP 400 with a clear error instead of 404.
- Harden the PM API milestone-lock and mutation-fingerprint guards so roadmap or manifest corruption yields explicit 4xx guidance instead of uncaught 5xx errors.
- Prevent start-milestone-session from silently overwriting existing active or pending_mr milestones by rejecting re-entry with guidance to reconcile-milestone-status.

Enhancements:
- Refine specy_road.__version__ resolution to favor a sibling pyproject.toml, fall back to importlib metadata, and remain resilient to malformed configuration.
- Apply natural numeric sorting for roadmap display IDs across CLI, exports, and PM Gantt so identifiers like M1.2 sort before M1.10.
- Refactor roadmap mutation handling and milestone reconciliation logic to satisfy per-function file-length limits without changing behavior.
- Track repository agent and workflow policy rules in-version, including release/version/tag sync guidance and git workflow conventions.

Build:
- Update pyproject.toml to set the package version to 0.1.0 for the first stable PyPI release and link the changelog to the v0.1.0 GitHub release tag.

Documentation:
- Add a detailed v0.1.0 changelog section summarizing features, lifecycle changes, error-handling improvements, and linking to the release tag.
- Update changelog comparison links to reference v0.1.0 as the latest released baseline.

Tests:
- Expand the test suite to cover version resolution behavior, PM API milestone locking, error-handling paths, milestone reconciliation, and re-entry guards, increasing total passing tests from 480 to 495.