### PR TITLE
release: v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ body. Keep section bodies focused; link to PRs for detail.
 
 ## [Unreleased]
 
+## [v0.1.3] - 2026-04-25
+
+Patch release. Publishes the post-`v0.1.2` release-readiness hardening:
+the restored pre-release validation runbook, the completed three-app
+user-testing pass, and a docs cleanup found by that pass. Routes to
+**PyPI** via OIDC trusted publisher.
+
+### Changed
+
+- **Release runbook pre-release validation.** Restores the mandatory
+  `WIP/pre-release-checks` branch before any `chore/release-*` branch,
+  requires `suggested_prompts/` compliance + cleanup review before fix
+  branches, and documents the three-app user-testing harness (ToDo,
+  Calculator, personal notes) with PM CLI, dev CLI, and desktop PM GUI
+  evidence requirements.
+- **Install guide post-PyPI wording.** Removes stale "Stable PyPI
+  pending" / TODO prose and makes `pip install specy-road` the primary
+  end-user install path.
+
+### Validation
+
+- Completed the restored pre-release validation pass against the
+  `v0.1.1..v0.1.2` delta plus current `dev` process-hardening changes.
+- Exercised three disposable consumer repos with local bare remotes:
+  ToDo, Calculator, and personal notes.
+- Ran PM CLI authoring/validation flows, dev CLI pickup/finish/abort
+  flows, and desktop PM GUI editing on the moderate Calculator roadmap.
+
 ## [v0.1.2] - 2026-04-25
 
 Patch release. Ships the accumulated `WIP/improvements-0-1-2` work
@@ -503,7 +531,8 @@ the package wheel is correct.
   only cares that `integration_branch` is declared; the rest is the
   user's git hygiene. (F-005)
 
-[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/shanevigil/specy-road/compare/v0.1.3...HEAD
+[v0.1.3]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.3
 [v0.1.2]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.2
 [v0.1.1]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.1
 [v0.1.0]: https://github.com/shanevigil/specy-road/releases/tag/v0.1.0

--- a/docs/install-and-usage.md
+++ b/docs/install-and-usage.md
@@ -3,14 +3,6 @@
 This is the **end-user** install and everyday usage guide. For toolkit-
 contributor topics (branching, tagging, PR workflow, release gating, npm
 build, supply-chain audits) see [contributor-guide.md](contributor-guide.md).
-That guide will be linked from the README **post-release**; until then,
-read it from the source tree.
-
-> **Stable PyPI pending.** Install from source from the `dev` branch (below).
-> **Prerelease** tags publish to **TestPyPI**; once **v0.1.0** is on PyPI,
-> `pip install specy-road` will work from the default index and this guide will
-> call that out. See **[contributor-guide.md](contributor-guide.md)** for
-> release flow and TestPyPI install notes.
 
 ---
 
@@ -27,7 +19,22 @@ read it from the source tree.
 
 ---
 
-## Install (from source)
+## Install
+
+For application teams, install the published package from PyPI:
+
+```bash
+pip install specy-road
+```
+
+Optional extras:
+
+```bash
+pip install "specy-road[gui-next]"  # PM Gantt UI deps
+pip install "specy-road[review]"    # LLM review (`specy-road review-node`)
+```
+
+## Install from source (toolkit contributors)
 
 ```bash
 git clone https://github.com/shanevigil/specy-road.git

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -165,7 +165,7 @@ Run the prompts docs-first exactly as instructed in:
 - [`suggested_prompts/compliance_prompts.md`](../suggested_prompts/compliance_prompts.md)
 - [`suggested_prompts/cleanup_prompts.md`](../suggested_prompts/cleanup_prompts.md)
 
-Use the previous released tag as the baseline:
+Use the previous release tag as the baseline:
 
 ```bash
 git fetch origin --tags
@@ -173,8 +173,18 @@ git log --oneline vX.Y.Z..HEAD
 git diff --name-only vX.Y.Z..HEAD
 ```
 
-Where `vX.Y.Z` is the latest live release (for example, a final
-`v0.1.2` pre-release pass starts from `v0.1.1`).
+Baseline rule:
+
+- For the first RC or a final with no RCs, diff from the latest
+  **final** tag (for example, a `v0.1.2` final with no RCs uses
+  `v0.1.1..HEAD`).
+- For follow-up RCs in the same train, diff from the previous RC tag
+  (for example, `v0.2.0-rc1..HEAD` before cutting `v0.2.0-rc2`), and
+  include a short note confirming the latest final-to-current delta
+  was already reviewed earlier in the train.
+- For a final after one or more RCs, diff from the latest RC tag for
+  post-RC changes, then also skim the latest-final-to-HEAD summary so
+  the final release notes still cover the whole train.
 
 At minimum, apply these prompt sections to the changed code/docs:
 
@@ -195,6 +205,17 @@ toolkit (roadmap validation/export/file-limits, `pytest`, PM Gantt
 lint/test/build when `gui/pm-gantt/` changed, and supply-chain audits).
 
 ### 3.3 Three-app user-testing harness
+
+Minimum evidence to capture in the release PR/body or an attached
+`work/pre-release-checks-<version>.md` note:
+
+- app repo paths + remotes for all three disposable apps
+- exact CLI commands run (or a terminal log path) and final pass/fail
+  result for each app
+- selected node IDs used for brief generation, pickup, completion, or
+  abort testing
+- PM GUI screenshot/recording artifact paths for the desktop test
+- any accepted warnings from §3.2 with rationale
 
 Create three disposable consumer app repositories outside this toolkit
 checkout (for example under `/tmp/specy-road-pre-release-apps/`):

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -82,6 +82,7 @@ flagged "user runs this".
 |---|------|-------|-----|
 | 2.1 | `git fetch && git checkout dev && git pull --ff-only` | agent | sync. |
 | 2.2 | Decide RC vs final, choose version number | agent (with user) | needs user intent. |
+| 2.2a | Complete the mandatory pre-release checks branch (§3) | agent | prompt-driven cleanup/compliance + 3-app user testing must pass before any release branch is cut. |
 | 2.3 | Cut `chore/release-vX-Y-Z[-rcN]` branch | agent | naming is load-bearing. |
 | 2.4 | Bump `pyproject.toml` `project.version` to PEP 440 form | agent | exact format matters. |
 | 2.5 | Add `## [vX.Y.Z[-rcN]] - YYYY-MM-DD` to `CHANGELOG.md` | agent | uses today's UTC date. |
@@ -98,6 +99,160 @@ flagged "user runs this".
 | 2.16 | Back-merge `main → dev` | agent | mirror of `7236352` from rc4. |
 | 2.17 | Cleanup: delete the `chore/release-...` branch + any `cursor/...` session aliases | agent | leave only `main`, `dev`, and active feature branches. |
 | 2.18 | **Confirm the release is live** (final: PyPI page; RC: TestPyPI page) | **user** | the agent reports the URLs and waits for the user's "looks good" before signing off. |
+
+---
+
+## 3. Mandatory pre-release checks branch (before `chore/release-*`)
+
+Before cutting **any** RC or final release branch, prove the current
+candidate line is ready from a user's point of view. This is a
+release-readiness branch, not the release branch.
+
+### 3.1 Branch order
+
+1. Sync the integration line:
+
+   ```bash
+   git fetch --all --prune
+   git checkout dev
+   git pull --ff-only origin dev
+   ```
+
+   If maintainers have an active `WIP/improvements-x-y-z` batch for
+   the release train, start from that branch instead of raw `dev`.
+
+2. Create the pre-release validation branch:
+
+   ```bash
+   git checkout -b WIP/pre-release-checks
+   git push -u origin WIP/pre-release-checks
+   ```
+
+3. **Before creating any fix branches**, run the
+   [`suggested_prompts/`](../suggested_prompts/) cleanup and compliance
+   prompts against the delta from the previous release tag to this
+   candidate branch. The prompt pass is first because it marshals the
+   agent to review what changed since the last release against the
+   repository's documented standards.
+
+4. If the prompt pass finds issues, create short-lived branches from
+   `WIP/pre-release-checks` (for example
+   `fix/pre-release-cli-contract`, `fix/pre-release-pm-gui`, or
+   `docs/pre-release-prompt-alignment`), fix one logical issue per
+   branch, and merge each branch back into `WIP/pre-release-checks`.
+   Re-run the relevant prompt/gate after each merge.
+
+5. Run the three-app user-testing harness in §3.3 on the updated
+   `WIP/pre-release-checks` branch. If user testing finds issues, use
+   the same short-lived-branch pattern, merge back into
+   `WIP/pre-release-checks`, and re-run the affected checks.
+
+6. When **all** prompt checks and app tests pass, merge
+   `WIP/pre-release-checks` back into `dev` (or into the active
+   release-train WIP branch if that is the agreed integration line).
+   Only after that merge may the operator cut
+   `chore/release-vX-Y-Z[-rcN]`.
+
+If the entire pass produces no code/docs changes, record the passing
+evidence in the release notes/PR body and delete
+`WIP/pre-release-checks`. Do **not** cut the release branch until this
+branch is green or explicitly closed as no-op.
+
+### 3.2 Prompt-driven cleanup and compliance pass
+
+Run the prompts docs-first exactly as instructed in:
+
+- [`suggested_prompts/compliance_prompts.md`](../suggested_prompts/compliance_prompts.md)
+- [`suggested_prompts/cleanup_prompts.md`](../suggested_prompts/cleanup_prompts.md)
+
+Use the previous released tag as the baseline:
+
+```bash
+git fetch origin --tags
+git log --oneline vX.Y.Z..HEAD
+git diff --name-only vX.Y.Z..HEAD
+```
+
+Where `vX.Y.Z` is the latest live release (for example, a final
+`v0.1.2` pre-release pass starts from `v0.1.1`).
+
+At minimum, apply these prompt sections to the changed code/docs:
+
+- **Architecture & Vision Compliance**
+- **Scoped Code Review** against the previous release tag
+- **Test Coverage Gap Audit**
+- **Dependency Audit** and **Security Audit** when dependencies,
+  packaging, subprocess behavior, path handling, GUI/API surfaces, or
+  release workflows changed
+- **Pre-Release Gate Check**
+- From cleanup prompts: **File & Function Size Enforcement**,
+  **Documentation Hygiene**, and **Dead Code Cleanup**
+
+Every FAIL is a release blocker. A WARNING must either be fixed or
+explicitly accepted in the release notes/PR body with rationale. Use
+the command substitutions documented in the prompt files for this
+toolkit (roadmap validation/export/file-limits, `pytest`, PM Gantt
+lint/test/build when `gui/pm-gantt/` changed, and supply-chain audits).
+
+### 3.3 Three-app user-testing harness
+
+Create three disposable consumer app repositories outside this toolkit
+checkout (for example under `/tmp/specy-road-pre-release-apps/`):
+
+1. **ToDo application**
+2. **Calculator application**
+3. **Personal notes app**
+
+Install the candidate toolkit from the `WIP/pre-release-checks` checkout
+into a fresh virtual environment and use that `specy-road` executable
+for all app tests. Each app must be a real git repo with a configured
+remote (a local bare remote is fine) so registry and branch workflows
+exercise the same assumptions as users' repos.
+
+At least one of the three apps must have a **moderate-complexity
+roadmap**, not just a smoke scaffold. The moderate roadmap should
+include multiple phases, gates, dependencies, planning sheets, shared
+contracts, and enough leaf tasks to exercise ordering, validation,
+brief generation, and registry pickup.
+
+For each app, run the PM-oriented CLI flow:
+
+- `specy-road init project`
+- roadmap authoring commands such as `add-node`, `edit-node`,
+  dependency updates, and gate status updates as appropriate for the
+  app's roadmap
+- `specy-road validate`
+- `specy-road export --check` (then `specy-road export` if the index
+  intentionally changed)
+- `specy-road file-limits`
+
+For each app, run the developer-oriented CLI flow:
+
+- generate at least one `specy-road brief <NODE_ID>`
+- pick up at least one eligible leaf with
+  `specy-road do-next-available-task`
+- verify the registry claim is committed/pushed on the integration
+  branch and that the feature branch is created
+- complete or abort the pickup using the documented command path for
+  the scenario under test, then verify the registry is clean
+
+For at least one app (preferably the moderate roadmap), run the PM GUI
+through the desktop environment:
+
+- launch `specy-road gui --repo-root <APP_REPO>`
+- open the dashboard in the browser
+- create or edit a task, update dependencies/gate status where
+  applicable, and save
+- exercise planning/shared-document editing if those surfaces changed
+  in the release candidate
+- validate that the GUI write is reflected on disk and that
+  `specy-road validate` plus `specy-road export --check` pass
+
+Capture evidence for the release PR/body: commands run, app paths,
+selected node IDs, GUI screenshots or recordings when GUI behavior was
+changed, and the final pass/fail result for each app. Remove disposable
+apps after the release unless the user explicitly asks to keep them for
+inspection.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "specy-road"
 # Canonical version: `specy_road.__version__` prefers this file when the
 # package lives under this repo; else importlib.metadata; else `0.0.0+unknown`.
-version = "0.1.2"
+version = "0.1.3"
 description = "Roadmap-first coordination kit for humans and AI agents"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final PyPI release for `v0.1.3`.

Publishes the post-`v0.1.2` validation fixes:
- restored pre-release validation runbook section (already merged to `dev`)
- post-PyPI install guide cleanup found by the prompt-driven cleanup pass
- release metadata for `v0.1.3`

The release body will be sourced from the `## [v0.1.3]` section in `CHANGELOG.md`.

## Pre-release validation evidence

- Evidence artifact: `/opt/cursor/artifacts/pre-release-checks-v0.1.2.md`
- PM GUI recording: `/opt/cursor/artifacts/pm-gui-calculator-validation.mp4`
- Three disposable apps validated with local bare remotes:
  - ToDo: `/tmp/specy-road-pre-release-apps/todo-app`
  - Calculator: `/tmp/specy-road-pre-release-apps/calculator-app`
  - Notes: `/tmp/specy-road-pre-release-apps/notes-app`

## Local verification

- `python scripts/check_release_version.py v0.1.3`
- `specy-road validate --repo-root tests/fixtures/specy_road_dogfood`
- `specy-road export --check --repo-root tests/fixtures/specy_road_dogfood`
- `specy-road file-limits`
- `pytest -q` (543 passed)
- `cd gui/pm-gantt && npm ci && npm run lint && npm test && npm run build`
- `pip-audit --skip-editable --ignore-vuln CVE-2026-3219` (current pip CVE has no published fixed version; repo deps otherwise clean)
- `cd gui/pm-gantt && npm audit --omit=dev`

Refs #56
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2fca5dd-3444-44be-bf66-01ac20fa0d0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2fca5dd-3444-44be-bf66-01ac20fa0d0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Summary by Sourcery

Prepare the v0.1.3 patch release, documenting the restored pre-release validation process, updating user-facing installation instructions for the now-published PyPI package, and bumping the project version metadata.

Enhancements:
- Document a mandatory pre-release validation branch with prompt-driven compliance checks and a three-app user-testing harness in the release runbook.
- Clarify and streamline the install guide to make PyPI the default end-user installation path while keeping source install instructions for contributors.
- Record the v0.1.3 release in the changelog with notes on validation evidence and process hardening.

Build:
- Bump the package version in pyproject.toml to v0.1.3 and update changelog comparison links for the new tag.

Documentation:
- Update release and install documentation to reflect the new pre-release validation flow and the availability of specy-road on PyPI.